### PR TITLE
Cross compiling fixes and improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,18 +17,6 @@ include("cmake/Hunter/init.cmake")
 cmake_policy(SET CMP0048 NEW)
 project(libp2p VERSION 0.0.1 LANGUAGES C CXX)
 
-include(cmake/print.cmake)
-print("C flags: ${CMAKE_C_FLAGS}")
-print("CXX flags: ${CMAKE_CXX_FLAGS}")
-print("Using CMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}")
-
-include(CheckCXXCompilerFlag)
-include(cmake/install.cmake)
-include(cmake/libp2p_add_library.cmake)
-include(cmake/dependencies.cmake)
-include(cmake/functions.cmake)
-include(cmake/san.cmake)
-
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 option(TESTING "Build tests" ON)
@@ -43,6 +31,18 @@ option(MSAN "Enable memory sanitizer" OFF)
 option(TSAN "Enable thread sanitizer" OFF)
 option(UBSAN "Enable UB sanitizer" OFF)
 option(EXPOSE_MOCKS "Make mocks header files visible for child projects" OFF)
+
+include(cmake/print.cmake)
+print("C flags: ${CMAKE_C_FLAGS}")
+print("CXX flags: ${CMAKE_CXX_FLAGS}")
+print("Using CMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}")
+
+include(CheckCXXCompilerFlag)
+include(cmake/install.cmake)
+include(cmake/libp2p_add_library.cmake)
+include(cmake/dependencies.cmake)
+include(cmake/functions.cmake)
+include(cmake/san.cmake)
 
 
 ## setup compilation flags

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -1,7 +1,14 @@
-# https://docs.hunter.sh/en/latest/packages/pkg/GTest.html
-hunter_add_package(GTest)
-find_package(GTest CONFIG REQUIRED)
-find_package(GMock CONFIG REQUIRED)
+#
+# Copyright Soramitsu Co., Ltd. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+if (TESTING)
+  # https://docs.hunter.sh/en/latest/packages/pkg/GTest.html
+  hunter_add_package(GTest)
+  find_package(GTest CONFIG REQUIRED)
+  find_package(GMock CONFIG REQUIRED)
+endif()
 
 # https://docs.hunter.sh/en/latest/packages/pkg/Boost.html
 hunter_add_package(Boost COMPONENTS random filesystem program_options)

--- a/cmake/functions.cmake
+++ b/cmake/functions.cmake
@@ -45,8 +45,13 @@ function(add_flag flag)
 endfunction()
 
 function(compile_proto_to_cpp PROTO_LIBRARY_NAME PB_H PB_CC PROTO)
-  get_target_property(Protobuf_INCLUDE_DIR protobuf::libprotobuf INTERFACE_INCLUDE_DIRECTORIES)
-  get_target_property(Protobuf_PROTOC_EXECUTABLE protobuf::protoc IMPORTED_LOCATION_RELEASE)
+  if (NOT Protobuf_INCLUDE_DIR)
+    get_target_property(Protobuf_INCLUDE_DIR protobuf::libprotobuf INTERFACE_INCLUDE_DIRECTORIES)
+  endif()
+  if (NOT Protobuf_PROTOC_EXECUTABLE)
+    get_target_property(Protobuf_PROTOC_EXECUTABLE protobuf::protoc IMPORTED_LOCATION_RELEASE)
+    set(PROTOBUF_DEPENDS protobuf::protoc)
+  endif()
 
   if (NOT Protobuf_PROTOC_EXECUTABLE)
     message(FATAL_ERROR "Protobuf_PROTOC_EXECUTABLE is empty")
@@ -78,7 +83,7 @@ function(compile_proto_to_cpp PROTO_LIBRARY_NAME PB_H PB_CC PROTO)
       COMMAND ${GEN_COMMAND}
       ARGS -I${PROJECT_SOURCE_DIR}/src -I${GEN_ARGS} --cpp_out=${SCHEMA_OUT_DIR} ${PROTO_ABS}
       WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-      DEPENDS protobuf::protoc
+      DEPENDS ${PROTOBUF_DEPENDS}
       VERBATIM
   )
 

--- a/src/common/literals.cpp
+++ b/src/common/literals.cpp
@@ -11,6 +11,8 @@
 #include <libp2p/multi/multihash.hpp>
 #include <libp2p/peer/peer_id.hpp>
 
+#include <algorithm>
+
 namespace libp2p::common {
   libp2p::common::Hash256 operator""_hash256(const char *c, size_t s) {
     libp2p::common::Hash256 hash{};

--- a/src/common/literals.cpp
+++ b/src/common/literals.cpp
@@ -16,13 +16,13 @@
 namespace libp2p::common {
   libp2p::common::Hash256 operator""_hash256(const char *c, size_t s) {
     libp2p::common::Hash256 hash{};
-    std::copy_n(c, std::min(s, 32ul), hash.rbegin());
+    std::copy_n(c, std::min(s, static_cast<size_t>(32u)), hash.rbegin());
     return hash;
   }
 
   libp2p::common::Hash512 operator""_hash512(const char *c, size_t s) {
     libp2p::common::Hash512 hash{};
-    std::copy_n(c, std::min(s, 64ul), hash.rbegin());
+    std::copy_n(c, std::min(s, static_cast<size_t>(64u)), hash.rbegin());
     return hash;
   }
 

--- a/src/muxer/yamux/yamux_frame.cpp
+++ b/src/muxer/yamux/yamux_frame.cpp
@@ -100,7 +100,7 @@ namespace libp2p::connection {
   }
 
   boost::optional<YamuxFrame> parseFrame(gsl::span<const uint8_t> frame_bytes) {
-    if (frame_bytes.size() < YamuxFrame::kHeaderLength) {
+    if (frame_bytes.size() < static_cast<int>(YamuxFrame::kHeaderLength)) {
       return {};
     }
 


### PR DESCRIPTION
## Description

This PR contains a set of fixes and improvements to the build system to allow for cross-compiling, and then applies several code fixes needed for newer GCC versions.

### Structure of the PR

The PR is organized as follows:

1. Improvements needed for cross-compiling
2. Build fixes

### Improvements for cross-compiling

Commits:

- [CMake: Expose CMake options to includes](https://github.com/eigendude/libp2p/commit/cross-compile~5)
- [CMake: Exclude test dependencies when building tests](https://github.com/eigendude/libp2p/commit/cross-compile~4)
- [CMake: Allow build system to provide protobuf compiler](https://github.com/eigendude/libp2p/commit/cross-compile~3)

These changes enable more control over the build process when embedding in another build system.

CMake is controlled by user variables; the first one we need is `-DHUNTER_ENABLED=OFF` so that we can have control over dependencies.

Another useful variable is `-DTESTING=OFF`, because embedding test infra drastically increases the up-front effort. The first commit above allows this variable to exclude test infra from the dependency discovery in addition to the build.

Finally, I added two variables to allow the build system to provide the protobuf compiler and headers:

* `-DProtobuf_PROTOC_EXECUTABLE=$(NATIVEPREFIX)/bin/protoc`
* `-DProtobuf_INCLUDE_DIR=$(PREFIX)/include`

We might also want to disable `-Werror` for examples, but I haven't done that here.

### Build fixes

Commits:

- [Fix build error due to missing include](https://github.com/eigendude/libp2p/commit/cross-compile~2)
- [Fix build error due to mismatched types](https://github.com/eigendude/libp2p/commit/cross-compile~1)
- [Fix compiler warning due to sign comparison](https://github.com/eigendude/libp2p/commit/cross-compile)

These fixes should be evident by visual inspection. Error log included in the commit messages.

## How has this been tested?

With these changes in place, I'm able to compile and link libp2p and dependencies using two build systems: OpenEmbedded, and Kodi's depends system.

Here's my work on these two build systems. Commits are structured so that libp2p inclusion can be upstreamed.

### Additions for OpenEmbedded (meta-cryptocurrency layer)

Commits:

* [libp2p: Import C++ implementation of libp2p](https://github.com/eigendude/meta-cryptocurrency/commit/filecoin~1)

This commit enables libp2p support in the OpenEmbedded ecosystem.

### Additions for Kodi

Commits for C++17 support:

* [[docs] Update Linux readmes for C++17 requirement](https://github.com/eigendude/kodi/commit/filecoin~7)
* [[depends] Check for C++17 support](https://github.com/eigendude/kodi/commit/filecoin~6)
* [Change to C++17 for core](https://github.com/eigendude/kodi/commit/filecoin~5)

Kodi currently uses C++14. These 3 commits can be PR'd to enable C++17 support, needed for libp2p and filecoin. Merging is probably a long way off, as Kodi supports a long tail of devices with embedded build systems that often use old compilers.

Commits for the depends build system:

* [tools/depends: Update OpenSSL to v1.1.1](https://github.com/eigendude/kodi/commit/filecoin~4)
* [tools/depends: Add libp2p and dependencies](https://github.com/eigendude/kodi/commit/filecoin~3)

With the commits in this PR, I was able to cross-compile libp2p for x86_64 Linux and macOS for runtime testing. Next is to test compilation for Raspberry Pi and Android NDK.

Commits for runtime testing:

* [testing libp2p: echo, kademlia and gossip](https://github.com/eigendude/kodi/commit/filecoin)

I didn't spend a lot of time on kademlia, but echo and gossip test code produces promising output. Tested on Linux x86_64 and macOS.

## Benefits

IoT is the obvious goal, but Kodi opens up another little-known area of embedded: OTT (over-the-top), stretching across both set-top boxes and almost all mobile

## Related PRs

This PR is needed for https://github.com/filecoin-project/cpp-filecoin/pull/114.
