### PR TITLE
Use vector in write queue

### DIFF
--- a/include/libp2p/muxer/mplex/mplex_stream.hpp
+++ b/include/libp2p/muxer/mplex/mplex_stream.hpp
@@ -115,7 +115,7 @@ namespace libp2p::connection {
     bool data_notified_ = false;
 
     /// Queue of write requests that were received when stream was writing
-    std::deque<std::tuple<gsl::span<const uint8_t>, size_t, WriteCallbackFunc>>
+    std::deque<std::tuple<std::vector<uint8_t>, size_t, WriteCallbackFunc>>
         write_queue_{};
 
     mutable std::mutex write_queue_mutex_;

--- a/include/libp2p/muxer/yamux/yamux_stream.hpp
+++ b/include/libp2p/muxer/yamux/yamux_stream.hpp
@@ -164,7 +164,7 @@ namespace libp2p::connection {
 
     /// Queue of write requests that were received when stream was writing
     std::deque<
-        std::tuple<gsl::span<const uint8_t>, size_t, WriteCallbackFunc, bool>>
+        std::tuple<std::vector<uint8_t>, size_t, WriteCallbackFunc, bool>>
         write_queue_{};
 
     mutable std::mutex write_queue_mutex_;

--- a/src/muxer/mplex/mplex_stream.cpp
+++ b/src/muxer/mplex/mplex_stream.cpp
@@ -135,9 +135,8 @@ namespace libp2p::connection {
     if (bytes == 0 || in.empty() || static_cast<size_t>(in.size()) < bytes) {
       return cb(Error::INVALID_ARGUMENT);
     }
-    std::vector<uint8_t> in_vector(in.size());
-    std::copy(in.begin(), in.end(), in_vector.begin());
     if (is_writing_) {
+      std::vector<uint8_t> in_vector(in.begin(), in.end());
       std::lock_guard<std::mutex> lock(write_queue_mutex_);
       write_queue_.emplace_back(in_vector, bytes, cb);
       return;
@@ -148,7 +147,7 @@ namespace libp2p::connection {
 
     is_writing_ = true;
     connection_.lock()->streamWrite(
-        stream_id_, in_vector, bytes,
+        stream_id_, in, bytes,
         [self{shared_from_this()}, cb{std::move(cb)}](auto &&write_res) {
           self->is_writing_ = false;
           if (!write_res) {

--- a/src/muxer/mplex/mplex_stream.cpp
+++ b/src/muxer/mplex/mplex_stream.cpp
@@ -137,7 +137,10 @@ namespace libp2p::connection {
     }
     if (is_writing_) {
       std::lock_guard<std::mutex> lock(write_queue_mutex_);
-      write_queue_.emplace_back(in, bytes, cb);
+      std::vector<uint8_t> in_vector;
+      in_vector.reserve(in.size());
+      std::copy(in.begin(), in.end(), in_vector.begin());
+      write_queue_.emplace_back(in_vector, bytes, cb);
       return;
     }
     if (connection_.expired()) {

--- a/src/muxer/mplex/mplex_stream.cpp
+++ b/src/muxer/mplex/mplex_stream.cpp
@@ -135,11 +135,10 @@ namespace libp2p::connection {
     if (bytes == 0 || in.empty() || static_cast<size_t>(in.size()) < bytes) {
       return cb(Error::INVALID_ARGUMENT);
     }
+    std::vector<uint8_t> in_vector(in.size());
+    std::copy(in.begin(), in.end(), in_vector.begin());
     if (is_writing_) {
       std::lock_guard<std::mutex> lock(write_queue_mutex_);
-      std::vector<uint8_t> in_vector;
-      in_vector.reserve(in.size());
-      std::copy(in.begin(), in.end(), in_vector.begin());
       write_queue_.emplace_back(in_vector, bytes, cb);
       return;
     }
@@ -149,7 +148,7 @@ namespace libp2p::connection {
 
     is_writing_ = true;
     connection_.lock()->streamWrite(
-        stream_id_, in, bytes,
+        stream_id_, in_vector, bytes,
         [self{shared_from_this()}, cb{std::move(cb)}](auto &&write_res) {
           self->is_writing_ = false;
           if (!write_res) {

--- a/src/muxer/yamux/yamux_stream.cpp
+++ b/src/muxer/yamux/yamux_stream.cpp
@@ -197,7 +197,10 @@ namespace libp2p::connection {
     }
     if (is_writing_) {
       std::lock_guard<std::mutex> lock(write_queue_mutex_);
-      write_queue_.emplace_back(in, bytes, cb, some);
+      std::vector<uint8_t> in_vector;
+      in_vector.reserve(in.size());
+      std::copy(in.begin(), in.end(), in_vector.begin());
+      write_queue_.emplace_back(in_vector, bytes, cb, some);
       return;
     }
 


### PR DESCRIPTION
# Description

Using gsl::span in write queue in streams might be dangerous, as span does not store collection itself, but rather stores only pointer and size of the collection