### PR TITLE
Fix/asio scheduler

### DIFF
--- a/src/protocol/common/asio/asio_scheduler.cpp
+++ b/src/protocol/common/asio/asio_scheduler.cpp
@@ -15,7 +15,10 @@ namespace libp2p::protocol {
         interval_(config.period_msec),
         timer_(io, boost::posix_time::milliseconds(interval_)),
         started_(boost::posix_time::microsec_clock::local_time()),
-        timer_cb_([this](const boost::system::error_code &) { onTimer(); }),
+        timer_cb_([this](const boost::system::error_code &error) {
+          if (!error)
+            onTimer();
+        }),
         immediate_cb_([this] { onImmediate(); }) {
     assert(interval_ > 0 && interval_ <= 1000);
     timer_.async_wait(timer_cb_);

--- a/test/libp2p/protocol/CMakeLists.txt
+++ b/test/libp2p/protocol/CMakeLists.txt
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+add_subdirectory(common)
 add_subdirectory(kademlia)
 add_subdirectory(gossip)
 

--- a/test/libp2p/protocol/common/CMakeLists.txt
+++ b/test/libp2p/protocol/common/CMakeLists.txt
@@ -1,0 +1,6 @@
+#
+# Copyright Soramitsu Co., Ltd. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+add_subdirectory(asio)

--- a/test/libp2p/protocol/common/asio/CMakeLists.txt
+++ b/test/libp2p/protocol/common/asio/CMakeLists.txt
@@ -1,0 +1,21 @@
+#
+# Copyright Soramitsu Co., Ltd. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+addtest(asio_scheduler_test
+    asio_scheduler_test.cpp
+    )
+target_link_libraries(asio_scheduler_test
+    asio_scheduler
+
+    p2p_basic_host
+    p2p_default_network
+    p2p_peer_repository
+    p2p_inmem_address_repository
+    p2p_inmem_key_repository
+    p2p_inmem_protocol_repository
+    p2p_literals
+    p2p_kad
+    asio_scheduler
+    )

--- a/test/libp2p/protocol/common/asio/asio_scheduler_test.cpp
+++ b/test/libp2p/protocol/common/asio/asio_scheduler_test.cpp
@@ -1,0 +1,21 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "libp2p/protocol/common/asio/asio_scheduler.hpp"
+
+#include <gtest/gtest.h>
+#include <libp2p/injector/host_injector.hpp>
+
+using libp2p::protocol::Scheduler;
+
+TEST(AsioScheduler, Construct) {
+  auto injector = libp2p::injector::makeHostInjector();
+  auto context = injector.create<std::shared_ptr<boost::asio::io_context>>();
+  std::shared_ptr<Scheduler> scheduler =
+      std::make_shared<libp2p::protocol::AsioScheduler>(
+          *context, libp2p::protocol::SchedulerConfig{});
+  scheduler.reset();
+  context->run();
+}

--- a/test/libp2p/protocol/common/asio/asio_scheduler_test.cpp
+++ b/test/libp2p/protocol/common/asio/asio_scheduler_test.cpp
@@ -10,6 +10,12 @@
 
 using libp2p::protocol::Scheduler;
 
+/**
+ * @given Constructs AsioScheduler and schedules on io context and then deletes
+ * AsioScheduler
+ * @when context is run
+ * @then scheduler called and can handle cancellation timer without segfault
+ */
 TEST(AsioScheduler, Construct) {
   auto injector = libp2p::injector::makeHostInjector();
   auto context = injector.create<std::shared_ptr<boost::asio::io_context>>();


### PR DESCRIPTION
1st commit shows a test with problem in AsioScheduler - it calles onTimer after being deleted.

'boost::asio::deadline_timer' calls scheduled event after being deleted with error code set. So, need to check error coded before handler.