### PR TITLE
Fix handling addresses starting from p2p

### DIFF
--- a/src/multi/multiaddress.cpp
+++ b/src/multi/multiaddress.cpp
@@ -175,7 +175,7 @@ namespace libp2p::multi {
     if (protocol == nullptr) {
       return {};
     }
-    auto proto_str = "/"s + std::string(protocol->name);
+    auto proto_str = "/"s + std::string(protocol->name) + "/";
     auto proto_positions =
         findSubstringOccurrences(stringified_address_, proto_str);
     if (proto == Protocol::Code::P2P) {  // ipfs and p2p are equivalent

--- a/test/libp2p/multi/multiaddress_test.cpp
+++ b/test/libp2p/multi/multiaddress_test.cpp
@@ -251,7 +251,11 @@ TEST_F(MultiaddressTest, GetProtocolsWithValues) {
  */
 TEST_F(MultiaddressTest, DnsAndIpfs) {
   auto addr =
-      "/dns4/kusama-bootnode-1.paritytech.net/tcp/30333/p2p/QmV32G18YzenpNFmhqg2n7TtdjYRK7oU6FhLbDL4oRgsbe"s;
+      "/dns4/p2p.cc3-0.kusama.network/tcp/30100/p2p/12D3KooWDgtynm4S9M3m6ZZhXYu2RrWKdvkCSScc25xKDVSg1Sjd"s;
   EXPECT_OUTCOME_TRUE(address, Multiaddress::create(addr));
   ASSERT_EQ(address.getStringAddress(), addr);
+  auto peer_id_opt = address.getPeerId();
+  ASSERT_TRUE(peer_id_opt);
+  ASSERT_EQ(peer_id_opt.value(),
+            "12D3KooWDgtynm4S9M3m6ZZhXYu2RrWKdvkCSScc25xKDVSg1Sjd");
 }


### PR DESCRIPTION
# Description

Parsing in multiaddr is buggy. 

Example. Consider multiaddr `/dns4/p2p.cc3-0.kusama.network/tcp/30100/p2p/12D3KooWDgtynm4S9M3m6ZZhXYu2RrWKdvkCSScc25xKDVSg1Sjd`

GetPeerId on that multiaddr returns `tcp`, because it returns first word after word containing /p2p. However p2p is part of dns address. Current PR fixes that