### PR TITLE
Filecoin codec and hash types

### DIFF
--- a/include/libp2p/multi/hash_type.hpp
+++ b/include/libp2p/multi/hash_type.hpp
@@ -7,8 +7,8 @@
 #define LIBP2P_HASH_TYPE_HPP
 
 namespace libp2p::multi {
-  /// TODO(Harrm) FIL-14: Hash types are a part of multicodec table, it would be good to
-  /// move them there to avoid duplication and allow for extraction of
+  /// TODO(Harrm) FIL-14: Hash types are a part of multicodec table, it would be
+  /// good to move them there to avoid duplication and allow for extraction of
   /// human-friendly name of a type from its code
   /// @see MulticodecType
   /// https://github.com/multiformats/js-multihash/blob/master/src/constants.js
@@ -19,7 +19,9 @@ namespace libp2p::multi {
     sha512 = 0x13,
     blake2b_256 = 0xb220,
     blake2s128 = 0xb250,
-    blake2s256 = 0xb260
+    blake2s256 = 0xb260,
+    sha2_256_trunc254_padded = 0x1012,
+    poseidon_bls12_381_a1_fc1 = 0xb401,
   };
 }  // namespace libp2p::multi
 

--- a/include/libp2p/multi/multicodec_type.hpp
+++ b/include/libp2p/multi/multicodec_type.hpp
@@ -33,6 +33,8 @@ namespace libp2p::multi {
       RAW = 0x55,
       DAG_PB = 0x70,
       DAG_CBOR = 0x71,
+      FILECOIN_COMMITMENT_UNSEALED = 0xf101,
+      FILECOIN_COMMITMENT_SEALED = 0xf102,
     };
 
     static std::string getName(Code code) {
@@ -59,6 +61,10 @@ namespace libp2p::multi {
           return "dag-pb";
         case Code::DAG_CBOR:
           return "dag-cbor";
+        case Code::FILECOIN_COMMITMENT_UNSEALED:
+          return "fil-commitment-unsealed";
+        case Code::FILECOIN_COMMITMENT_SEALED:
+          return "fil-commitment-sealed";
       }
       return "unknown";
     }


### PR DESCRIPTION
Added codecs:
- Sealed Filecoin commitment
- Unsealed Filecoin commitment

Added hashes:
- sha2 256 trunc254 padded
- poseidon bls12 381 a1 fc1