### PR TITLE
Noise::write now reports the correct amount of bytes

### DIFF
--- a/include/libp2p/security/noise/noise_connection.hpp
+++ b/include/libp2p/security/noise/noise_connection.hpp
@@ -69,6 +69,7 @@ namespace libp2p::connection {
     std::shared_ptr<security::noise::InsecureReadWriter> framer_;
     size_t already_read_;
     size_t already_wrote_;
+    size_t plaintext_len_to_write_;
     common::ByteArray writing_;
     common::Logger log_ = common::createLogger("NoiseConn");
   };


### PR DESCRIPTION
The initial implementation was reporting the raw-wire amount of bytes written which was not equal to the length of user-level plaintext for sending over the connection. 
As the result user's callback on write completion got a non-representative amount of bytes written.
The changes makes the noise secured connection report the proper amount of bytes written for the user's level of data representation.

Signed-off-by: Igor Egorov <igor@soramitsu.co.jp>