### PR TITLE
Fix Dialing to Peers (allow use all peers' addresses)

### DIFF
--- a/src/network/impl/dialer_impl.cpp
+++ b/src/network/impl/dialer_impl.cpp
@@ -30,35 +30,76 @@ namespace libp2p::network {
       return;
     }
 
+    struct DialHandlerCtx {
+      bool connected;
+      size_t calls_remain;
+      DialResultFunc cb;
+
+      DialHandlerCtx(size_t addresses, DialResultFunc cb)
+          : connected(false), calls_remain(addresses), cb{std::move(cb)} {}
+    };
+    auto handler_ctx = std::make_shared<DialHandlerCtx>(p.addresses.size(), cb);
+    auto dial_handler =
+        [listener{listener_}, ctx{std::move(handler_ctx)}](
+            outcome::result<std::shared_ptr<connection::CapableConnection>>
+                connection_result) {
+          --ctx->calls_remain;
+          if (ctx->connected) {
+            // we already got connected to the peer via some other address
+            if (connection_result) {
+              // lets close the redundant connection if so
+              auto &&conn = connection_result.value();
+              if (not conn->isClosed()) {
+                auto close_res = conn->close();
+                BOOST_ASSERT(close_res);
+              }
+            }  // otherwise we don't care about any failure since that was going
+               // to be a redundant connection to the moment
+            return;
+          }
+
+          if (connection_result) {
+            // we've got the first successful connection to the peer, hooray!
+            ctx->connected = true;
+            // allow the connection accept inbound streams
+            listener->onConnection(connection_result);
+            // return connection to the user
+            ctx->cb(connection_result.value());
+            return;
+          }
+
+          // here we handle failed attempt to connect
+          if (0 == ctx->calls_remain) {
+            // that was the last attempt to connect and we are still not
+            // connected so lets report an error to the user
+            ctx->cb(connection_result.error());
+            return;
+          }  // otherwise we don't care about this particular failure because at
+             // the end we either would get connected or will do the same -
+             // report the error to the user inside the callback of the last
+             // dial attempt
+        };
+
+    bool dialled{false};
     // for all multiaddresses supplied in peerinfo
     for (auto &&ma : p.addresses) {
       // try to find best possible transport
       if (auto tr = this->tmgr_->findBest(ma); tr != nullptr) {
         // we can dial to this peer!
+        dialled = true;
         // dial using best transport
-        tr->dial(
-            p.id, ma,
-            [this, cb{std::move(cb)}, pid{p.id}](
-                outcome::result<std::shared_ptr<connection::CapableConnection>>
-                    rconn) {
-              if (!rconn) {
-                cb(rconn.error());
-                return;
-              }
-
-              // allow the connection to accept inbound streams
-              this->listener_->onConnection(rconn);
-
-              // return connection to the user
-              cb(rconn.value());
-            },
-            timeout);
-        return;
+        tr->dial(p.id, ma, dial_handler, timeout);
+        // All the dials are still to be executed sequentially within the single
+        // boost::asio::io_context. Immediate spawn of all of them allows us to
+        // have the closest timeout to the specified instead of
+        // NumberOfMultiaddresses multiplied by a single timeout value.
       }
     }
 
-    // we did not find supported transport
-    cb(std::errc::address_family_not_supported);
+    if (not dialled) {
+      // we did not find supported transport
+      cb(std::errc::address_family_not_supported);
+    }
   }
 
   void DialerImpl::newStream(const peer::PeerInfo &p,

--- a/test/libp2p/network/dialer_test.cpp
+++ b/test/libp2p/network/dialer_test.cpp
@@ -55,11 +55,53 @@ struct DialerTest : public ::testing::Test {
       std::make_shared<DialerImpl>(proto_muxer, tmgr, cmgr, listener);
 
   multi::Multiaddress ma1 = "/ip4/127.0.0.1/tcp/1"_multiaddr;
+  multi::Multiaddress ma2 = "/ip4/127.0.0.1/tcp/2"_multiaddr;
   peer::PeerId pid = "1"_peerid;
   peer::Protocol protocol = "/protocol/1.0.0";
 
   peer::PeerInfo pinfo{.id = pid, .addresses = {ma1}};
+  peer::PeerInfo pinfo_two_addrs{.id = pid, .addresses = {ma1, ma2}};
 };
+
+/**
+ * @given a peer with two multiaddresses
+ * @when a dial to the first address fails
+ * @then the dialer will try the second supplied address too
+ */
+TEST_F(DialerTest, DialAllTheAddresses) {
+  // we dont have connection already
+  EXPECT_CALL(*cmgr, getBestConnectionForPeer(pinfo.id))
+      .WillOnce(Return(nullptr));
+
+  // connection is stored
+  EXPECT_CALL(*listener, onConnection(_)).Times(1);
+
+  // we have transport to dial
+  EXPECT_CALL(*tmgr, findBest(ma1)).WillOnce(Return(transport));
+  EXPECT_CALL(*tmgr, findBest(ma2)).WillOnce(Return(transport));
+
+  // transport->dial returns an error for the first address
+  EXPECT_CALL(
+      *transport,
+      dial(pinfo_two_addrs.id, ma1, _, std::chrono::milliseconds::zero()))
+      .WillOnce(
+          Arg2CallbackWithArg(outcome::failure(std::errc::connection_refused)));
+
+  // transport->dial returns valid connection for the second address
+  EXPECT_CALL(
+      *transport,
+      dial(pinfo_two_addrs.id, ma2, _, std::chrono::milliseconds::zero()))
+      .WillOnce(Arg2CallbackWithArg(outcome::success(connection)));
+
+  bool executed = false;
+  dialer->dial(pinfo_two_addrs, [&](auto &&rconn) {
+    EXPECT_OUTCOME_TRUE(conn, rconn);
+    (void)conn;
+    executed = true;
+  });
+
+  ASSERT_TRUE(executed);
+}
 
 /**
  * @given no known connections to peer, have 1 transport, 1 address supplied


### PR DESCRIPTION
Addresses #96 

Initial behavior: in the best case, the dialer did a single attempt to connect to the peer using its first available address.

Corrected behavior: the dialer enumerates and tries all the supplied peer's addresses while trying to connect.

Also added a test:
```
ctest -R dialer_test --output-on-failure
```
The test will not pass in the current master branch without the fix.