### PR TITLE
Fix default logger configurator at injection

### DIFF
--- a/include/libp2p/log/configurator.hpp
+++ b/include/libp2p/log/configurator.hpp
@@ -8,10 +8,14 @@
 
 #include <soralog/impl/configurator_from_yaml.hpp>
 
+#include <boost/di.hpp>
+
 namespace libp2p::log {
 
   class Configurator : public soralog::ConfiguratorFromYAML {
    public:
+    BOOST_DI_INJECT_TRAITS();
+
     Configurator();
 
     explicit Configurator(std::string config);


### PR DESCRIPTION
Logging system configurator has two ctors: default and second one with a single argument (yaml-content of config). At injection second one is called with empty string, what gets wrong behavior, although expected first of them. Second one is used only for overriden config.

This PR force to use default ctor of logger configurator at dependency injection.
