### PR TITLE
Outbound streams optimistic creation

### DIFF
--- a/include/libp2p/connection/capable_connection.hpp
+++ b/include/libp2p/connection/capable_connection.hpp
@@ -42,6 +42,12 @@ namespace libp2p::connection {
     virtual void stop() = 0;
 
     /**
+     * @brief Opens new stream in a synchronous (optimistic) manner
+     * @return Stream or error
+     */
+    virtual outcome::result<std::shared_ptr<Stream>> newStream() = 0;
+
+    /**
      * @brief Opens new stream using this connection
      * @param cb - callback to be called, when a new stream is established or
      * error appears

--- a/include/libp2p/host/basic_host/basic_host.hpp
+++ b/include/libp2p/host/basic_host/basic_host.hpp
@@ -61,6 +61,9 @@ namespace libp2p::host {
                    const StreamResultHandler &handler,
                    std::chrono::milliseconds timeout) override;
 
+    void newStream(const peer::PeerId &peer_id, const peer::Protocol &protocol,
+                   const StreamResultHandler &handler) override;
+
     outcome::result<void> listen(const multi::Multiaddress &ma) override;
 
     outcome::result<void> closeListener(const multi::Multiaddress &ma) override;

--- a/include/libp2p/host/host.hpp
+++ b/include/libp2p/host/host.hpp
@@ -177,6 +177,17 @@ namespace libp2p {
     }
 
     /**
+     * @brief Open new stream to the peer {@param peer} with protocol
+     * {@param protocol} in optimistic way. Assuming that connection exists.
+     * @param peer stream will be opened to this peer
+     * @param protocol "speak" using this protocol
+     * @param handler callback, will be executed on success or fail
+     */
+    virtual void newStream(
+        const peer::PeerId &peer_id, const peer::Protocol &protocol,
+        const StreamResultHandler &handler) = 0;
+
+    /**
      * @brief Create listener on given multiaddress.
      * @param ma address
      * @return may return error

--- a/include/libp2p/muxer/mplex/mplexed_connection.hpp
+++ b/include/libp2p/muxer/mplex/mplexed_connection.hpp
@@ -46,6 +46,8 @@ namespace libp2p::connection {
 
     void stop() override;
 
+    outcome::result<std::shared_ptr<Stream>> newStream() override;
+
     void newStream(StreamHandlerFunc cb) override;
 
     void onStream(NewStreamHandlerFunc cb) override;

--- a/include/libp2p/muxer/yamux/yamuxed_connection.hpp
+++ b/include/libp2p/muxer/yamux/yamuxed_connection.hpp
@@ -48,6 +48,8 @@ namespace libp2p::connection {
 
     void stop() override;
 
+    outcome::result<std::shared_ptr<Stream>> newStream() override;
+
     void newStream(StreamHandlerFunc cb) override;
 
     void onStream(NewStreamHandlerFunc cb) override;

--- a/include/libp2p/network/dialer.hpp
+++ b/include/libp2p/network/dialer.hpp
@@ -59,6 +59,14 @@ namespace libp2p::network {
       newStream(peer_info, protocol, std::move(cb),
                 std::chrono::milliseconds::zero());
     }
+
+    /**
+     * NewStream returns a new stream to given peer p.
+     * If there is no connection to p, returns error.
+     */
+    virtual void newStream(const peer::PeerId &peer_id,
+                           const peer::Protocol &protocol,
+                           StreamResultFunc cb) = 0;
   };
 
 }  // namespace libp2p::network

--- a/include/libp2p/network/impl/dialer_impl.hpp
+++ b/include/libp2p/network/impl/dialer_impl.hpp
@@ -33,6 +33,9 @@ namespace libp2p::network {
                    StreamResultFunc cb,
                    std::chrono::milliseconds timeout) override;
 
+    void newStream(const peer::PeerId &peer_id, const peer::Protocol &protocol,
+                   StreamResultFunc cb) override;
+
    private:
     std::shared_ptr<protocol_muxer::ProtocolMuxer> multiselect_;
     std::shared_ptr<TransportManager> tmgr_;

--- a/src/host/basic_host/basic_host.cpp
+++ b/src/host/basic_host/basic_host.cpp
@@ -119,6 +119,12 @@ namespace libp2p::host {
     network_->getDialer().newStream(p, protocol, handler, timeout);
   }
 
+  void BasicHost::newStream(const peer::PeerId &peer_id,
+                            const peer::Protocol &protocol,
+                            const StreamResultHandler &handler) {
+    network_->getDialer().newStream(peer_id, protocol, handler);
+  }
+
   outcome::result<void> BasicHost::listen(const multi::Multiaddress &ma) {
     return network_->getListener().listen(ma);
   }

--- a/src/muxer/yamux/yamuxed_connection.cpp
+++ b/src/muxer/yamux/yamuxed_connection.cpp
@@ -103,6 +103,7 @@ namespace libp2p::connection {
     auto stream_id = new_stream_id_;
     new_stream_id_ += 2;
     enqueue(newStreamMsg(stream_id));
+    enqueue(windowUpdateMsg(stream_id, YamuxFrame::kInitialWindowSize));
     pending_outbound_streams_[stream_id] = std::move(cb);
   }
 

--- a/src/network/impl/dialer_impl.cpp
+++ b/src/network/impl/dialer_impl.cpp
@@ -144,12 +144,12 @@ namespace libp2p::network {
 
     auto conn = cmgr_->getBestConnectionForPeer(peer_id);
     if (!conn) {
-      cb(std::errc::not_connected);
+      return cb(std::errc::not_connected);
     }
 
     auto result = conn->newStream();
     if (!result) {
-      cb(result);
+      return cb(result);
     }
 
     multiselect_->simpleStreamNegotiate(result.value(), protocol,

--- a/test/mock/libp2p/connection/capable_connection_mock.hpp
+++ b/test/mock/libp2p/connection/capable_connection_mock.hpp
@@ -16,6 +16,8 @@ namespace libp2p::connection {
    public:
     ~CapableConnectionMock() override = default;
 
+    MOCK_METHOD0(newStream, outcome::result<std::shared_ptr<Stream>>());
+
     MOCK_METHOD1(newStream, void(StreamHandlerFunc));
 
     MOCK_METHOD1(onStream, void(NewStreamHandlerFunc));
@@ -59,6 +61,7 @@ namespace libp2p::connection {
 
     ~CapableConnBasedOnRawConnMock() override = default;
 
+    MOCK_METHOD0(newStream, outcome::result<std::shared_ptr<Stream>>());
     MOCK_METHOD1(newStream, void(StreamHandlerFunc));
 
     MOCK_METHOD1(onStream, void(NewStreamHandlerFunc));

--- a/test/mock/libp2p/host/host_mock.hpp
+++ b/test/mock/libp2p/host/host_mock.hpp
@@ -42,6 +42,9 @@ namespace libp2p {
                  void(const peer::PeerInfo &p, const peer::Protocol &protocol,
                       const StreamResultHandler &handler,
                       std::chrono::milliseconds));
+    MOCK_METHOD3(newStream,
+                 void(const peer::PeerId &p, const peer::Protocol &protocol,
+                     const StreamResultHandler &handler));
     MOCK_METHOD1(listen, outcome::result<void>(const multi::Multiaddress &ma));
     MOCK_METHOD1(closeListener,
                  outcome::result<void>(const multi::Multiaddress &ma));

--- a/test/mock/libp2p/network/dialer_mock.hpp
+++ b/test/mock/libp2p/network/dialer_mock.hpp
@@ -24,6 +24,9 @@ namespace libp2p::network {
     MOCK_METHOD4(newStream,
                  void(const peer::PeerInfo &, const peer::Protocol &,
                       StreamResultFunc, std::chrono::milliseconds));
+    MOCK_METHOD3(newStream,
+                 void(const peer::PeerId &, const peer::Protocol &,
+                     StreamResultFunc));
   };
 
 }  // namespace libp2p::network


### PR DESCRIPTION
This resolves interop issues with some other libp2p implementations, which don't send ACK on inbound stream until they see data