### PR TITLE
Non-reentant dialer component

### DIFF
--- a/include/libp2p/network/impl/dialer_impl.hpp
+++ b/include/libp2p/network/impl/dialer_impl.hpp
@@ -6,6 +6,7 @@
 #ifndef LIBP2P_DIALER_IMPL_HPP
 #define LIBP2P_DIALER_IMPL_HPP
 
+#include <libp2p/basic/scheduler.hpp>
 #include <libp2p/network/connection_manager.hpp>
 #include <libp2p/network/dialer.hpp>
 #include <libp2p/network/listener_manager.hpp>
@@ -21,7 +22,8 @@ namespace libp2p::network {
     DialerImpl(std::shared_ptr<protocol_muxer::ProtocolMuxer> multiselect,
                std::shared_ptr<TransportManager> tmgr,
                std::shared_ptr<ConnectionManager> cmgr,
-               std::shared_ptr<ListenerManager> listener);
+               std::shared_ptr<ListenerManager> listener,
+               std::shared_ptr<basic::Scheduler> scheduler);
 
     // Establishes a connection to a given peer
     void dial(const peer::PeerInfo &p, DialResultFunc cb,
@@ -41,6 +43,7 @@ namespace libp2p::network {
     std::shared_ptr<TransportManager> tmgr_;
     std::shared_ptr<ConnectionManager> cmgr_;
     std::shared_ptr<ListenerManager> listener_;
+    std::shared_ptr<basic::Scheduler> scheduler_;
   };
 
 }  // namespace libp2p::network

--- a/test/acceptance/p2p/host/peer/test_peer.cpp
+++ b/test/acceptance/p2p/host/peer/test_peer.cpp
@@ -164,8 +164,8 @@ Peer::sptr<host::BasicHost> Peer::makeHost(const crypto::KeyPair &keyPair) {
   auto listener = std::make_shared<network::ListenerManagerImpl>(
       multiselect, std::move(router), tmgr, cmgr);
 
-  auto dialer =
-      std::make_unique<network::DialerImpl>(multiselect, tmgr, cmgr, listener);
+  auto dialer = std::make_unique<network::DialerImpl>(multiselect, tmgr, cmgr,
+                                                      listener, scheduler_);
 
   auto network = std::make_unique<network::NetworkImpl>(
       std::move(listener), std::move(dialer), cmgr);

--- a/test/libp2p/network/CMakeLists.txt
+++ b/test/libp2p/network/CMakeLists.txt
@@ -52,4 +52,5 @@ addtest(dialer_test
 target_link_libraries(dialer_test
     p2p_dialer
     p2p_literals
+    p2p_async_testutil
     )


### PR DESCRIPTION
Dialer component is not reentrant. 
This prevents higher level protocol implementation from potential bugs and allows for more clear design 