### PR TITLE
Gossip self cleanup

### DIFF
--- a/example/03-gossip/gossip_chat_example.cpp
+++ b/example/03-gossip/gossip_chat_example.cpp
@@ -108,7 +108,7 @@ int main(int argc, char *argv[]) {
 
   // create gossip node
   auto gossip = libp2p::protocol::gossip::create(
-      injector.create<std::shared_ptr<libp2p::protocol::Scheduler>>(), host,
+      injector.create<std::shared_ptr<libp2p::basic::Scheduler>>(), host,
       std::move(config));
 
   using Message = libp2p::protocol::gossip::Gossip::Message;

--- a/include/libp2p/log/sublogger.hpp
+++ b/include/libp2p/log/sublogger.hpp
@@ -25,7 +25,9 @@ namespace libp2p::log {
                        std::string_view prefix)
         : log_(log::createLogger(tag, group)),
           prefix_(prefix),
-          prefix_size_(prefix_.size()) {}
+          prefix_size_(prefix_.size() + 1) {
+      prefix_ += ' ';
+    }
 
     template <typename T>
     explicit SubLogger(const std::string &tag, const std::string &group,

--- a/include/libp2p/muxer/yamux/yamux_reading_state.hpp
+++ b/include/libp2p/muxer/yamux/yamux_reading_state.hpp
@@ -21,8 +21,8 @@ namespace libp2p::connection {
     using HeaderCallback =
         std::function<bool(boost::optional<YamuxFrame> header)>;
 
-    /// Callback on data segments, returns false to terminate further processing
-    using DataCallback = std::function<bool(
+    /// Callback on data segments
+    using DataCallback = std::function<void(
         gsl::span<uint8_t> segment, StreamId stream_id, bool rst, bool fin)>;
 
 
@@ -44,7 +44,7 @@ namespace libp2p::connection {
     bool processHeader(gsl::span<uint8_t> &bytes_read);
 
     /// Processes data message fragment from incoming data stream
-    bool processData(gsl::span<uint8_t> &bytes_read);
+    void processData(gsl::span<uint8_t> &bytes_read);
 
     /// Header cb
     HeaderCallback on_header_;

--- a/include/libp2p/muxer/yamux/yamuxed_connection.hpp
+++ b/include/libp2p/muxer/yamux/yamuxed_connection.hpp
@@ -227,6 +227,9 @@ namespace libp2p::connection {
     /// Timer handle for pings
     basic::Scheduler::Handle ping_handle_;
 
+    /// Cleanup for detached streams
+    basic::Scheduler::Handle cleanup_handle_;
+
     /// Timer handle for auto closing if inactive
     basic::Scheduler::Handle inactivity_handle_;
 

--- a/include/libp2p/muxer/yamux/yamuxed_connection.hpp
+++ b/include/libp2p/muxer/yamux/yamuxed_connection.hpp
@@ -131,15 +131,15 @@ namespace libp2p::connection {
     bool processHeader(boost::optional<YamuxFrame> header);
 
     /// Processes incoming data, called from YamuxReadingState
-    bool processData(gsl::span<uint8_t> segment, StreamId stream_id);
+    void processData(gsl::span<uint8_t> segment, StreamId stream_id);
 
     /// FIN received from peer to stream (either in header or with last data
     /// segment)
-    bool processFin(StreamId stream_id);
+    void processFin(StreamId stream_id);
 
     /// RST received from peer to stream (either in header or with last data
     /// segment)
-    bool processRst(StreamId stream_id);
+    void processRst(StreamId stream_id);
 
     /// Processes incoming GO_AWAY frame
     void processGoAway(const YamuxFrame &frame);

--- a/include/libp2p/peer/address_repository/inmem_address_repository.hpp
+++ b/include/libp2p/peer/address_repository/inmem_address_repository.hpp
@@ -59,13 +59,16 @@ namespace libp2p::peer {
     std::unordered_set<PeerId> getPeers() const override;
 
    private:
-    bool isNewDnsAddr(const multi::Multiaddress &ma);
-
     using ttlmap = std::unordered_map<multi::Multiaddress, Clock::time_point>;
     using ttlmap_ptr = std::shared_ptr<ttlmap>;
+    using peer_db = std::unordered_map<PeerId, ttlmap_ptr>;
+
+    bool isNewDnsAddr(const multi::Multiaddress &ma);
+
+    peer_db::iterator findOrInsert(const PeerId &p);
 
     std::shared_ptr<network::DnsaddrResolver> dnsaddr_resolver_;
-    std::unordered_map<PeerId, ttlmap_ptr> db_;
+    peer_db db_;
     std::set<multi::Multiaddress> resolved_dns_addrs_;
   };
 

--- a/include/libp2p/protocol/gossip/gossip.hpp
+++ b/include/libp2p/protocol/gossip/gossip.hpp
@@ -56,7 +56,11 @@ namespace libp2p::protocol::gossip {
         std::chrono::minutes(2)};
 
     /// Topic's message seen cache lifetime
-    std::chrono::milliseconds seen_cache_lifetime_msec{std::chrono::minutes(1)};
+    std::chrono::milliseconds seen_cache_lifetime_msec{
+        message_cache_lifetime_msec * 3 / 4};
+
+    /// Topic's seen cache limit
+    unsigned seen_cache_limit = 100;
 
     /// Heartbeat interval
     std::chrono::milliseconds heartbeat_interval_msec{1000};
@@ -65,7 +69,7 @@ namespace libp2p::protocol::gossip {
     std::chrono::milliseconds ban_interval_msec{std::chrono::minutes(1)};
 
     /// Max number of dial attempts before peer is forgotten
-    unsigned max_dial_attempts = 10;
+    unsigned max_dial_attempts = 3;
 
     /// Expiration of gossip peers' addresses in address repository
     std::chrono::milliseconds address_expiration_msec{std::chrono::hours(1)};

--- a/include/libp2p/protocol/gossip/gossip.hpp
+++ b/include/libp2p/protocol/gossip/gossip.hpp
@@ -6,6 +6,7 @@
 #ifndef LIBP2P_GOSSIP_HPP
 #define LIBP2P_GOSSIP_HPP
 
+#include <chrono>
 #include <functional>
 #include <set>
 #include <string>
@@ -20,7 +21,7 @@
 
 namespace libp2p {
   struct Host;
-  namespace protocol {
+  namespace basic {
     class Scheduler;
   }
 }  // namespace libp2p
@@ -48,13 +49,14 @@ namespace libp2p::protocol::gossip {
     bool echo_forward_mode = false;
 
     /// Read or write timeout per whole network operation
-    unsigned rw_timeout_msec = 10000;
+    std::chrono::milliseconds rw_timeout_msec {10000};
 
-    unsigned message_cache_lifetime_msec = 120000;
+    /// Lifetime of a message in message cache
+    std::chrono::milliseconds message_cache_lifetime_msec { 120000 };
 
-    unsigned seen_cache_lifetime_msec = 60000;
+    std::chrono::milliseconds seen_cache_lifetime_msec { 60000 };
 
-    unsigned heartbeat_interval_msec = 1000;
+    std::chrono::milliseconds heartbeat_interval_msec { 1000 };
 
     /// Max RPC message size
     size_t max_message_size = 1 << 24;
@@ -123,7 +125,7 @@ namespace libp2p::protocol::gossip {
   };
 
   // Creates Gossip object
-  std::shared_ptr<Gossip> create(std::shared_ptr<Scheduler> scheduler,
+  std::shared_ptr<Gossip> create(std::shared_ptr<basic::Scheduler> scheduler,
                                  std::shared_ptr<Host> host,
                                  Config config = Config{});
 

--- a/include/libp2p/protocol/gossip/gossip.hpp
+++ b/include/libp2p/protocol/gossip/gossip.hpp
@@ -49,25 +49,26 @@ namespace libp2p::protocol::gossip {
     bool echo_forward_mode = false;
 
     /// Read or write timeout per whole network operation
-    std::chrono::milliseconds rw_timeout_msec{10000};
+    std::chrono::milliseconds rw_timeout_msec{std::chrono::seconds(10)};
 
     /// Lifetime of a message in message cache
-    std::chrono::milliseconds message_cache_lifetime_msec{120000};
+    std::chrono::milliseconds message_cache_lifetime_msec{
+        std::chrono::minutes(2)};
 
     /// Topic's message seen cache lifetime
-    std::chrono::milliseconds seen_cache_lifetime_msec{60000};
+    std::chrono::milliseconds seen_cache_lifetime_msec{std::chrono::minutes(1)};
 
     /// Heartbeat interval
     std::chrono::milliseconds heartbeat_interval_msec{1000};
 
     /// Ban interval between dial attempts to peer
-    std::chrono::milliseconds ban_interval_msec{60000};
+    std::chrono::milliseconds ban_interval_msec{std::chrono::minutes(1)};
 
     /// Max number of dial attempts before peer is forgotten
     unsigned max_dial_attempts = 10;
 
     /// Expiration of gossip peers' addresses in address repository
-    std::chrono::milliseconds address_expiration_msec{3600000};
+    std::chrono::milliseconds address_expiration_msec{std::chrono::hours(1)};
 
     /// Max RPC message size
     size_t max_message_size = 1 << 24;

--- a/include/libp2p/protocol/gossip/gossip.hpp
+++ b/include/libp2p/protocol/gossip/gossip.hpp
@@ -49,14 +49,25 @@ namespace libp2p::protocol::gossip {
     bool echo_forward_mode = false;
 
     /// Read or write timeout per whole network operation
-    std::chrono::milliseconds rw_timeout_msec {10000};
+    std::chrono::milliseconds rw_timeout_msec{10000};
 
     /// Lifetime of a message in message cache
-    std::chrono::milliseconds message_cache_lifetime_msec { 120000 };
+    std::chrono::milliseconds message_cache_lifetime_msec{120000};
 
-    std::chrono::milliseconds seen_cache_lifetime_msec { 60000 };
+    /// Topic's message seen cache lifetime
+    std::chrono::milliseconds seen_cache_lifetime_msec{60000};
 
-    std::chrono::milliseconds heartbeat_interval_msec { 1000 };
+    /// Heartbeat interval
+    std::chrono::milliseconds heartbeat_interval_msec{1000};
+
+    /// Ban interval between dial attempts to peer
+    std::chrono::milliseconds ban_interval_msec{60000};
+
+    /// Max number of dial attempts before peer is forgotten
+    unsigned max_dial_attempts = 10;
+
+    /// Expiration of gossip peers' addresses in address repository
+    std::chrono::milliseconds address_expiration_msec{3600000};
 
     /// Max RPC message size
     size_t max_message_size = 1 << 24;
@@ -78,7 +89,8 @@ namespace libp2p::protocol::gossip {
 
     /// Adds bootstrap peer to the set of connectable peers
     virtual void addBootstrapPeer(
-        peer::PeerId id, boost::optional<multi::Multiaddress> address) = 0;
+        const peer::PeerId &id,
+        boost::optional<multi::Multiaddress> address) = 0;
 
     /// Adds bootstrap peer address in string form
     virtual outcome::result<void> addBootstrapPeer(

--- a/src/basic/scheduler/scheduler_impl.cpp
+++ b/src/basic/scheduler/scheduler_impl.cpp
@@ -222,7 +222,7 @@ namespace libp2p::basic {
 
         if (++first_cursor >= current_nc_items_.size()) {
           gsl::span<uint64_t> items(current_c_items_);
-          processCancellableItems(items.subspan(second_cursor), owner);
+          processCancellableItems(items.subspan(ssize_t(second_cursor)), owner);
           break;
         }
       } else {
@@ -234,7 +234,8 @@ namespace libp2p::basic {
 
         if (++second_cursor >= current_c_items_.size()) {
           gsl::span<Item> items(current_nc_items_);
-          processNonCancellableItems(items.subspan(first_cursor), owner);
+          processNonCancellableItems(items.subspan(ssize_t(first_cursor)),
+                                     owner);
           break;
         }
       }

--- a/src/basic/scheduler/scheduler_impl.cpp
+++ b/src/basic/scheduler/scheduler_impl.cpp
@@ -408,7 +408,7 @@ namespace libp2p::basic {
       uint64_t new_seq) {
     auto seq = ticket.second;
 
-    if (abs_time <= ticket.first || seq == 0 || new_seq <= seq) {
+    if (abs_time < ticket.first || seq == 0 || new_seq <= seq) {
       return Scheduler::Error::kInvalidArgument;
     }
 

--- a/src/muxer/yamux/yamux_reading_state.cpp
+++ b/src/muxer/yamux/yamux_reading_state.cpp
@@ -43,12 +43,12 @@ namespace libp2p::connection {
       if (data_bytes_unread_ == 0) {
         proceed = processHeader(bytes_read);
       } else {
-        proceed = processData(bytes_read);
+        processData(bytes_read);
       }
     }
   }
 
-  bool YamuxReadingState::processData(gsl::span<uint8_t> &bytes_read) {
+  void YamuxReadingState::processData(gsl::span<uint8_t> &bytes_read) {
     assert(data_bytes_unread_ > 0);
 
     auto bytes_available = size(bytes_read);
@@ -65,7 +65,7 @@ namespace libp2p::connection {
 
     if (read_data_stream_ == 0) {
       log()->debug("discarding {} data bytes", head.size());
-      return true;
+      return;
     }
 
     StreamId stream_id = read_data_stream_;
@@ -78,7 +78,7 @@ namespace libp2p::connection {
       reset();
     }
 
-    return on_data_(head, stream_id, rst, fin);
+    on_data_(head, stream_id, rst, fin);
   }
 
   bool YamuxReadingState::processHeader(gsl::span<uint8_t> &bytes_read) {

--- a/src/muxer/yamux/yamux_reading_state.cpp
+++ b/src/muxer/yamux/yamux_reading_state.cpp
@@ -23,7 +23,7 @@ namespace libp2p::connection {
 
     inline std::tuple<gsl::span<uint8_t>, gsl::span<uint8_t>> split(
         gsl::span<uint8_t> span, size_t n) {
-      return {span.subspan(0, n), span.subspan(n)};
+      return {span.subspan(0, ssize_t(n)), span.subspan(ssize_t(n))};
     }
 
   }  // namespace

--- a/src/muxer/yamux/yamuxed_connection.cpp
+++ b/src/muxer/yamux/yamuxed_connection.cpp
@@ -88,7 +88,7 @@ namespace libp2p::connection {
               // dont send pings if something is being written
               if (!is_writing_) {
                 enqueue(pingOutMsg(++ping_counter));
-                SL_DEBUG(log(), "written ping message #{}", ping_counter);
+                SL_TRACE(log(), "written ping message #{}", ping_counter);
               }
               std::ignore = ping_handle_.reschedule(config_.ping_interval);
             }

--- a/src/peer/address_repository/inmem_address_repository.cpp
+++ b/src/peer/address_repository/inmem_address_repository.cpp
@@ -63,11 +63,20 @@ namespace libp2p::peer {
     return false;
   }
 
+  InmemAddressRepository::peer_db::iterator
+  InmemAddressRepository::findOrInsert(const PeerId &p) {
+    auto it = db_.find(p);
+    if (it == db_.end()) {
+      it = db_.emplace(p, std::make_shared<ttlmap>()).first;
+    }
+    return it;
+  }
+
   outcome::result<bool> InmemAddressRepository::addAddresses(
       const PeerId &p, gsl::span<const multi::Multiaddress> ma,
       AddressRepository::Milliseconds ttl) {
     bool added = false;
-    auto peer_it = db_.emplace(p, std::make_shared<ttlmap>()).first;
+    auto peer_it = findOrInsert(p);
     auto &addresses = *peer_it->second;
 
     auto expires_at = Clock::now() + ttl;
@@ -85,7 +94,7 @@ namespace libp2p::peer {
       const PeerId &p, gsl::span<const multi::Multiaddress> ma,
       AddressRepository::Milliseconds ttl) {
     bool added = false;
-    auto peer_it = db_.emplace(p, std::make_shared<ttlmap>()).first;
+    auto peer_it = findOrInsert(p);
     auto &addresses = *peer_it->second;
 
     auto expires_at = Clock::now() + ttl;

--- a/src/protocol/gossip/impl/common.hpp
+++ b/src/protocol/gossip/impl/common.hpp
@@ -33,8 +33,8 @@ namespace libp2p::protocol::gossip {
   /// Shared buffer used to broadcast messages
   using SharedBuffer = std::shared_ptr<const ByteArray>;
 
-  /// Time may be any monotonic counter
-  using Time = uint64_t;
+  /// Time is scheduler's clock and counter
+  using Time = std::chrono::milliseconds;
 
   template <typename T>
   using Repeated = std::vector<T>;

--- a/src/protocol/gossip/impl/connectivity.cpp
+++ b/src/protocol/gossip/impl/connectivity.cpp
@@ -463,8 +463,8 @@ namespace libp2p::protocol::gossip {
     writable_peers_on_heartbeat_.clear();
 
     if (ts >= addresses_renewal_time_) {
-      addresses_renewal_time_ = scheduler_->now()
-          + config_.address_expiration_msec - std::chrono::milliseconds(500);
+      addresses_renewal_time_ =
+          scheduler_->now() + config_.address_expiration_msec * 9 / 10;
       auto &addr_repo = host_->getPeerRepository().getAddressRepository();
       connected_peers_.selectAll([this, &addr_repo](const PeerContextPtr &ctx) {
         std::ignore = addr_repo.updateAddresses(

--- a/src/protocol/gossip/impl/connectivity.cpp
+++ b/src/protocol/gossip/impl/connectivity.cpp
@@ -323,7 +323,7 @@ namespace libp2p::protocol::gossip {
       return;
     }
 
-    ctx->message_builder->clear();
+    ctx->message_builder->reset();
     for (auto &s : ctx->inbound_streams) {
       s->close();
     }

--- a/src/protocol/gossip/impl/connectivity.cpp
+++ b/src/protocol/gossip/impl/connectivity.cpp
@@ -338,7 +338,7 @@ namespace libp2p::protocol::gossip {
 
     if (++ctx->dial_attempts > config_.max_dial_attempts) {
       log_.info("removing peer {}", ctx->str);
-      if (!ctx.unique()) {
+      if (ctx.use_count() > 2) {
         log_.warn("{} extra links to peer still remain", ctx.use_count() - 1);
       }
       all_peers_.erase(ctx->peer_id);

--- a/src/protocol/gossip/impl/connectivity.cpp
+++ b/src/protocol/gossip/impl/connectivity.cpp
@@ -425,6 +425,9 @@ namespace libp2p::protocol::gossip {
       if (it->first > ts) {
         break;
       }
+
+      auto ctx = it->second;
+
       unban(it);
 
       log_.debug("dialing unbanned {}", ctx->str);

--- a/src/protocol/gossip/impl/connectivity.hpp
+++ b/src/protocol/gossip/impl/connectivity.hpp
@@ -113,9 +113,6 @@ namespace libp2p::protocol::gossip {
     /// Peers can be dialed to
     PeerSet connectable_peers_;
 
-    /// Peers currently connecting
-    PeerSet connecting_peers_;
-
     /// Peers temporary banned due to connectivity problems,
     /// will become connectable after certain interval
     BannedPeers banned_peers_expiration_;

--- a/src/protocol/gossip/impl/connectivity.hpp
+++ b/src/protocol/gossip/impl/connectivity.hpp
@@ -45,8 +45,8 @@ namespace libp2p::protocol::gossip {
     void stop();
 
     /// Adds bootstrap peer to the set of connectable peers
-    void addBootstrapPeer(peer::PeerId id,
-                          boost::optional<multi::Multiaddress> address);
+    void addBootstrapPeer(const peer::PeerId &id,
+                          const boost::optional<multi::Multiaddress> &address);
 
     /// Add peer to writable set, actual writes occur on flush() (piggybacking)
     /// The idea behind writable set and flush() is a compromise between
@@ -73,7 +73,10 @@ namespace libp2p::protocol::gossip {
     void handle(StreamResult rstream) override;
 
     /// Tries to connect to peer
-    void dial(const PeerContextPtr &peer, bool connection_must_exist);
+    void dial(const PeerContextPtr &peer);
+
+    /// Tries to connect to peer over existing connection
+    void dialOverExistingConnection(const PeerContextPtr &peer);
 
     /// Attaches new stream to peer context
     void onNewStream(std::shared_ptr<connection::Stream> stream,

--- a/src/protocol/gossip/impl/connectivity.hpp
+++ b/src/protocol/gossip/impl/connectivity.hpp
@@ -126,6 +126,9 @@ namespace libp2p::protocol::gossip {
     /// Peers to be flushed on next heartbeat
     PeerSet writable_peers_on_heartbeat_;
 
+    /// Renew addresses in address repo periodically within heartbeat timer
+    std::chrono::milliseconds addresses_renewal_time_ {0};
+
     /// Logger
     log::SubLogger log_;
   };

--- a/src/protocol/gossip/impl/connectivity.hpp
+++ b/src/protocol/gossip/impl/connectivity.hpp
@@ -113,6 +113,9 @@ namespace libp2p::protocol::gossip {
     /// Peers can be dialed to
     PeerSet connectable_peers_;
 
+    /// Peers currently connecting
+    PeerSet connecting_peers_;
+
     /// Peers temporary banned due to connectivity problems,
     /// will become connectable after certain interval
     BannedPeers banned_peers_expiration_;

--- a/src/protocol/gossip/impl/connectivity.hpp
+++ b/src/protocol/gossip/impl/connectivity.hpp
@@ -78,16 +78,17 @@ namespace libp2p::protocol::gossip {
     /// Tries to connect to peer over existing connection
     void dialOverExistingConnection(const PeerContextPtr &peer);
 
-    /// Attaches new stream to peer context
-    void onNewStream(std::shared_ptr<connection::Stream> stream,
-                     bool is_outbound);
+    /// Outbound stream result callback
+    void onNewStream(
+        const PeerContextPtr& ctx,
+        outcome::result<std::shared_ptr<connection::Stream>> rstream);
 
     /// Async feedback from streams
     void onStreamEvent(const PeerContextPtr &from,
                        outcome::result<Success> event);
 
     /// Bans peer from outbound candidates list for configured time interval
-    void ban(const PeerContextPtr &ctx);
+    void banOrForget(const PeerContextPtr &ctx);
 
     /// Unbans peer
     void unban(const PeerContextPtr &peer);

--- a/src/protocol/gossip/impl/connectivity.hpp
+++ b/src/protocol/gossip/impl/connectivity.hpp
@@ -6,12 +6,12 @@
 #ifndef LIBP2P_PROTOCOL_GOSSIP_CONNECTIVITY_HPP
 #define LIBP2P_PROTOCOL_GOSSIP_CONNECTIVITY_HPP
 
-#include <unordered_map>
 #include <map>
+#include <unordered_map>
 
+#include <libp2p/basic/scheduler.hpp>
 #include <libp2p/host/host.hpp>
 #include <libp2p/log/sublogger.hpp>
-#include <libp2p/protocol/common/scheduler.hpp>
 
 #include "peer_set.hpp"
 #include "stream.hpp"
@@ -32,7 +32,7 @@ namespace libp2p::protocol::gossip {
     using ConnectionStatusFeedback =
         std::function<void(bool connected, const PeerContextPtr &ctx)>;
 
-    Connectivity(Config config, std::shared_ptr<Scheduler> scheduler,
+    Connectivity(Config config, std::shared_ptr<basic::Scheduler> scheduler,
                  std::shared_ptr<Host> host,
                  std::shared_ptr<MessageReceiver> msg_receiver,
                  ConnectionStatusFeedback on_connected);
@@ -96,7 +96,7 @@ namespace libp2p::protocol::gossip {
     void flush(const PeerContextPtr &ctx) const;
 
     const Config config_;
-    std::shared_ptr<Scheduler> scheduler_;
+    std::shared_ptr<basic::Scheduler> scheduler_;
     std::shared_ptr<Host> host_;
     std::shared_ptr<MessageReceiver> msg_receiver_;
     ConnectionStatusFeedback connected_cb_;

--- a/src/protocol/gossip/impl/gossip_core.cpp
+++ b/src/protocol/gossip/impl/gossip_core.cpp
@@ -98,12 +98,10 @@ namespace libp2p::protocol::gossip {
       remote_subscriptions_->onSelfSubscribed(true, topic);
     }
 
-    heartbeat_timer_ = scheduler_->scheduleWithHandle(
-        [this] { onHeartbeat(); }, config_.heartbeat_interval_msec);
+    heartbeat_timer_ =
+        scheduler_->scheduleWithHandle([this] { onHeartbeat(); });
 
     connectivity_->start();
-
-    onHeartbeat();
   }
 
   void GossipCore::stop() {

--- a/src/protocol/gossip/impl/gossip_core.cpp
+++ b/src/protocol/gossip/impl/gossip_core.cpp
@@ -48,11 +48,11 @@ namespace libp2p::protocol::gossip {
   // clang-format on
 
   void GossipCore::addBootstrapPeer(
-      peer::PeerId id, boost::optional<multi::Multiaddress> address) {
-    bootstrap_peers_[id] = address;
+      const peer::PeerId &id, boost::optional<multi::Multiaddress> address) {
     if (started_) {
-      connectivity_->addBootstrapPeer(std::move(id), std::move(address));
+      connectivity_->addBootstrapPeer(id, address);
     }
+    bootstrap_peers_[id] = std::move(address);
   }
 
   outcome::result<void> GossipCore::addBootstrapPeer(
@@ -63,7 +63,7 @@ namespace libp2p::protocol::gossip {
       return multi::Multiaddress::Error::INVALID_INPUT;
     }
     OUTCOME_TRY(peer_id, peer::PeerId::fromBase58(*peer_id_str));
-    addBootstrapPeer(std::move(peer_id), {std::move(ma)});
+    addBootstrapPeer(peer_id, {std::move(ma)});
     return outcome::success();
   }
 

--- a/src/protocol/gossip/impl/gossip_core.cpp
+++ b/src/protocol/gossip/impl/gossip_core.cpp
@@ -175,7 +175,7 @@ namespace libp2p::protocol::gossip {
     if (subscribe) {
       remote_subscriptions_->onPeerSubscribed(peer, topic);
     } else {
-      remote_subscriptions_->onPeerUnsubscribed(peer, topic);
+      remote_subscriptions_->onPeerUnsubscribed(peer, topic, false);
     }
   }
 

--- a/src/protocol/gossip/impl/gossip_core.cpp
+++ b/src/protocol/gossip/impl/gossip_core.cpp
@@ -204,7 +204,7 @@ namespace libp2p::protocol::gossip {
       from->message_builder->addMessage(*msg_found.value(), msg_id);
       connectivity_->peerIsWritable(from, true);
     } else {
-      log_.warn("wanted message not in cache");
+      log_.debug("wanted message not in cache");
     }
   }
 

--- a/src/protocol/gossip/impl/gossip_core.hpp
+++ b/src/protocol/gossip/impl/gossip_core.hpp
@@ -10,9 +10,9 @@
 
 #include <map>
 
+#include <libp2p/basic/scheduler.hpp>
 #include <libp2p/host/host.hpp>
 #include <libp2p/log/sublogger.hpp>
-#include <libp2p/protocol/common/scheduler.hpp>
 
 #include "message_cache.hpp"
 #include "message_receiver.hpp"
@@ -34,7 +34,7 @@ namespace libp2p::protocol::gossip {
     GossipCore(GossipCore &&) = delete;
     GossipCore &operator=(GossipCore &&) = delete;
 
-    GossipCore(Config config, std::shared_ptr<Scheduler> scheduler,
+    GossipCore(Config config, std::shared_ptr<basic::Scheduler> scheduler,
                std::shared_ptr<Host> host);
 
     ~GossipCore() override = default;
@@ -43,10 +43,10 @@ namespace libp2p::protocol::gossip {
     // Gossip overrides
     void addBootstrapPeer(
         peer::PeerId id, boost::optional<multi::Multiaddress> address) override;
-    outcome::result<void> addBootstrapPeer(const std::string& address) override;
+    outcome::result<void> addBootstrapPeer(const std::string &address) override;
     void start() override;
     void stop() override;
-    void setValidator(const TopicId& topic, Validator validator) override;
+    void setValidator(const TopicId &topic, Validator validator) override;
     void setMessageIdFn(MessageIdFn fn) override;
     Subscription subscribe(TopicSet topics,
                            SubscriptionCallback callback) override;
@@ -85,7 +85,7 @@ namespace libp2p::protocol::gossip {
         bootstrap_peers_;
 
     /// Scheduler for timers and async calls
-    std::shared_ptr<Scheduler> scheduler_;
+    std::shared_ptr<basic::Scheduler> scheduler_;
 
     /// Host (interface to libp2p network)
     std::shared_ptr<Host> host_;
@@ -123,7 +123,7 @@ namespace libp2p::protocol::gossip {
     bool started_ = false;
 
     /// Heartbeat timer handle
-    Scheduler::Handle heartbeat_timer_;
+    basic::Scheduler::Handle heartbeat_timer_;
 
     /// Logger
     log::SubLogger log_;

--- a/src/protocol/gossip/impl/gossip_core.hpp
+++ b/src/protocol/gossip/impl/gossip_core.hpp
@@ -42,7 +42,8 @@ namespace libp2p::protocol::gossip {
    private:
     // Gossip overrides
     void addBootstrapPeer(
-        peer::PeerId id, boost::optional<multi::Multiaddress> address) override;
+        const peer::PeerId &id,
+        boost::optional<multi::Multiaddress> address) override;
     outcome::result<void> addBootstrapPeer(const std::string &address) override;
     void start() override;
     void stop() override;

--- a/src/protocol/gossip/impl/message_builder.cpp
+++ b/src/protocol/gossip/impl/message_builder.cpp
@@ -96,7 +96,12 @@ namespace libp2p::protocol::gossip {
       pb_msg_->release_control();
     }
 
-    clear();
+    static constexpr size_t kSizeThreshold = 8192;
+    if (msg_sz > kSizeThreshold) {
+      reset();
+    } else {
+      clear();
+    }
 
     if (success) {
       return buffer;

--- a/src/protocol/gossip/impl/message_builder.hpp
+++ b/src/protocol/gossip/impl/message_builder.hpp
@@ -32,11 +32,11 @@ namespace libp2p::protocol::gossip {
 
     ~MessageBuilder();
 
-    /// Clears constructed message
-    void clear();
+    /// Deep memory cleanup
+    void reset();
 
     /// Returns true if nothing added
-    bool empty();
+    bool empty() const;
 
     /// Serializes into byte buffer and clears internal state
     outcome::result<SharedBuffer> serialize();
@@ -60,6 +60,12 @@ namespace libp2p::protocol::gossip {
     void addMessage(const TopicMessage &msg, const MessageId &msg_id);
 
    private:
+    /// Creates protobuf structures if needed
+    void create_protobuf_structures();
+
+    /// Clears constructed message
+    void clear();
+
     /// Protobuf message being constructed
     std::unique_ptr<pubsub::pb::RPC> pb_msg_;
     std::unique_ptr<pubsub::pb::ControlMessage> control_pb_msg_;

--- a/src/protocol/gossip/impl/message_cache.cpp
+++ b/src/protocol/gossip/impl/message_cache.cpp
@@ -20,7 +20,7 @@ namespace libp2p::protocol::gossip {
 
   MessageCache::MessageCache(Time message_lifetime, TimeFunction clock)
       : message_lifetime_(message_lifetime), clock_(std::move(clock)) {
-    assert(message_lifetime_ > 0);
+    assert(message_lifetime_ > Time::zero());
     table_ = std::make_unique<msg_cache_table::Table>();
   }
 

--- a/src/protocol/gossip/impl/peer_context.hpp
+++ b/src/protocol/gossip/impl/peer_context.hpp
@@ -21,9 +21,6 @@ namespace libp2p::protocol::gossip {
     /// String repr for logging purposes
     const std::string str;
 
-    /// Not null iff this peer can be dialed to
-    boost::optional<multi::Multiaddress> dial_to;
-
     /// Builds message to be sent to this peer
     std::shared_ptr<MessageBuilder> message_builder;
 
@@ -36,6 +33,9 @@ namespace libp2p::protocol::gossip {
 
     /// Dialing to this peer is banned until this timestamp
     Time banned_until {0};
+
+    /// Current dial attempts
+    unsigned dial_attempts = 0;
 
     /// If true, then outbound connection is in progress
     bool is_connecting = false;

--- a/src/protocol/gossip/impl/peer_context.hpp
+++ b/src/protocol/gossip/impl/peer_context.hpp
@@ -35,7 +35,7 @@ namespace libp2p::protocol::gossip {
     std::vector<std::shared_ptr<Stream>> inbound_streams;
 
     /// Dialing to this peer is banned until this timestamp
-    Time banned_until = 0;
+    Time banned_until {0};
 
     /// If true, then outbound connection is in progress
     bool is_connecting = false;

--- a/src/protocol/gossip/impl/remote_subscriptions.cpp
+++ b/src/protocol/gossip/impl/remote_subscriptions.cpp
@@ -14,7 +14,7 @@ namespace libp2p::protocol::gossip {
 
   RemoteSubscriptions::RemoteSubscriptions(const Config &config,
                                            Connectivity &connectivity,
-                                           Scheduler &scheduler,
+                                           basic::Scheduler &scheduler,
                                            log::SubLogger &log)
       : config_(config),
         connectivity_(connectivity),
@@ -57,7 +57,7 @@ namespace libp2p::protocol::gossip {
   }
 
   void RemoteSubscriptions::onPeerUnsubscribed(const PeerContextPtr &peer,
-                                               TopicId topic) {
+                                               const TopicId &topic) {
     if (peer->subscribed_to.erase(topic) == 0) {
       // was not subscribed actually, ignore
       log_.debug("peer {} was not subscribed to {}", peer->str, topic);
@@ -116,7 +116,8 @@ namespace libp2p::protocol::gossip {
     if (!res) {
       return;
     }
-    res.value().onPrune(peer, scheduler_.now() + backoff_time * 1000);
+    res.value().onPrune(peer,
+                        scheduler_.now() + std::chrono::seconds(backoff_time));
   }
 
   void RemoteSubscriptions::onNewMessage(

--- a/src/protocol/gossip/impl/remote_subscriptions.cpp
+++ b/src/protocol/gossip/impl/remote_subscriptions.cpp
@@ -57,12 +57,14 @@ namespace libp2p::protocol::gossip {
   }
 
   void RemoteSubscriptions::onPeerUnsubscribed(const PeerContextPtr &peer,
-                                               const TopicId &topic) {
-    if (peer->subscribed_to.erase(topic) == 0) {
+                                               const TopicId &topic,
+                                               bool disconnected) {
+    if (!disconnected && peer->subscribed_to.erase(topic) == 0) {
       // was not subscribed actually, ignore
       log_.debug("peer {} was not subscribed to {}", peer->str, topic);
       return;
     }
+
     log_.debug("peer {} unsubscribing from {}", peer->str, topic);
     auto res = getItem(topic, false);
     if (!res) {
@@ -70,6 +72,7 @@ namespace libp2p::protocol::gossip {
       log_.debug("entry doesnt exist for {}", topic);
       return;
     }
+
     TopicSubscriptions &subs = res.value();
 
     subs.onPeerUnsubscribed(peer);
@@ -79,8 +82,11 @@ namespace libp2p::protocol::gossip {
   }
 
   void RemoteSubscriptions::onPeerDisconnected(const PeerContextPtr &peer) {
-    while (!peer->subscribed_to.empty()) {
-      onPeerUnsubscribed(peer, *peer->subscribed_to.begin());
+    std::set<std::string> subscribed_to;
+    subscribed_to.swap(peer->subscribed_to);
+
+    for (const auto& topic : subscribed_to) {
+      onPeerUnsubscribed(peer, topic, true);
     }
   }
 

--- a/src/protocol/gossip/impl/remote_subscriptions.hpp
+++ b/src/protocol/gossip/impl/remote_subscriptions.hpp
@@ -28,7 +28,8 @@ namespace libp2p::protocol::gossip {
     void onPeerSubscribed(const PeerContextPtr &peer, const TopicId &topic);
 
     /// Remote peer unsubscribes
-    void onPeerUnsubscribed(const PeerContextPtr &peer, const TopicId &topic);
+    void onPeerUnsubscribed(const PeerContextPtr &peer, const TopicId &topic,
+                            bool disconnected);
 
     /// Peer disconnected - remove it from all topics it's subscribed to
     void onPeerDisconnected(const PeerContextPtr &peer);

--- a/src/protocol/gossip/impl/remote_subscriptions.hpp
+++ b/src/protocol/gossip/impl/remote_subscriptions.hpp
@@ -7,7 +7,7 @@
 #define LIBP2P_PROTOCOL_GOSSIP_REMOTE_SUBSCRIPTIONS_HPP
 
 #include <libp2p/log/sublogger.hpp>
-#include <libp2p/protocol/common/scheduler.hpp>
+#include <libp2p/basic/scheduler.hpp>
 
 #include "topic_subscriptions.hpp"
 
@@ -19,7 +19,7 @@ namespace libp2p::protocol::gossip {
     /// Ctor. Dependencies are passed by ref becaus this object is a part of
     /// GossipCore and lives only within its scope
     RemoteSubscriptions(const Config &config, Connectivity &connectivity,
-                        Scheduler &scheduler, log::SubLogger &log);
+                        basic::Scheduler &scheduler, log::SubLogger &log);
 
     /// This host subscribes or unsubscribes
     void onSelfSubscribed(bool subscribed, const TopicId &topic);
@@ -28,7 +28,7 @@ namespace libp2p::protocol::gossip {
     void onPeerSubscribed(const PeerContextPtr &peer, const TopicId &topic);
 
     /// Remote peer unsubscribes
-    void onPeerUnsubscribed(const PeerContextPtr &peer, TopicId topic);
+    void onPeerUnsubscribed(const PeerContextPtr &peer, const TopicId &topic);
 
     /// Peer disconnected - remove it from all topics it's subscribed to
     void onPeerDisconnected(const PeerContextPtr &peer);
@@ -61,7 +61,7 @@ namespace libp2p::protocol::gossip {
 
     const Config &config_;
     Connectivity &connectivity_;
-    Scheduler &scheduler_;
+    basic::Scheduler &scheduler_;
 
     // TODO(artem): bound table size (which may grow!)
     // by removing items not subscribed to locally. LRU(???)

--- a/src/protocol/gossip/impl/stream.cpp
+++ b/src/protocol/gossip/impl/stream.cpp
@@ -229,10 +229,7 @@ namespace libp2p::protocol::gossip {
     reading_ = false;
     endWrite();
     closed_ = true;
-    stream_->close([self{shared_from_this()}](outcome::result<void>) {
-      log::createLogger("gossip")->debug("stream {} closed for peer {}",
-                                         self->stream_id_, self->peer_->str);
-    });
+    stream_->reset();
   }
 
 }  // namespace libp2p::protocol::gossip

--- a/src/protocol/gossip/impl/stream.cpp
+++ b/src/protocol/gossip/impl/stream.cpp
@@ -79,7 +79,7 @@ namespace libp2p::protocol::gossip {
 
     read_buffer_->resize(msg_len);
 
-    stream_->read(gsl::span(read_buffer_->data(), msg_len), msg_len,
+    stream_->read(gsl::span(read_buffer_->data(), ssize_t(msg_len)), msg_len,
                   [self_wptr = weak_from_this(), this,
                    buffer = read_buffer_](auto &&res) {
                     if (self_wptr.expired()) {
@@ -158,7 +158,7 @@ namespace libp2p::protocol::gossip {
 
     // clang-format off
     stream_->write(
-        gsl::span(data, writing_bytes_),
+        gsl::span(data, ssize_t(writing_bytes_)),
         writing_bytes_,
 
         [self_wptr = weak_from_this(), this, buffer = std::move(buffer)]

--- a/src/protocol/gossip/impl/stream.hpp
+++ b/src/protocol/gossip/impl/stream.hpp
@@ -8,9 +8,9 @@
 
 #include <deque>
 
+#include <libp2p/basic/scheduler.hpp>
 #include <libp2p/connection/stream.hpp>
 #include <libp2p/multi/uvarint.hpp>
-#include <libp2p/protocol/common/scheduler.hpp>
 
 #include "common.hpp"
 
@@ -29,7 +29,7 @@ namespace libp2p::protocol::gossip {
     /// by design, so dependencies are stored by reference.
     /// Also, peer is passed separately because it cannot be fetched from stream
     /// once the stream is dead
-    Stream(size_t stream_id, const Config &config, Scheduler &scheduler,
+    Stream(size_t stream_id, const Config &config, basic::Scheduler &scheduler,
            const Feedback &feedback, MessageReceiver &msg_receiver,
            std::shared_ptr<connection::Stream> stream, PeerContextPtr peer);
 
@@ -52,8 +52,8 @@ namespace libp2p::protocol::gossip {
     void asyncPostError(Error error);
 
     const size_t stream_id_;
-    const Scheduler::Ticks timeout_;
-    Scheduler &scheduler_;
+    const Time timeout_;
+    basic::Scheduler &scheduler_;
     const size_t max_message_size_;
     const Feedback &feedback_;
     MessageReceiver &msg_receiver_;
@@ -75,7 +75,7 @@ namespace libp2p::protocol::gossip {
     bool reading_ = false;
 
     /// Handle for current operation timeout guard
-    Scheduler::Handle timeout_handle_;
+    basic::Scheduler::Handle timeout_handle_;
   };
 
 }  // namespace libp2p::protocol::gossip

--- a/src/protocol/gossip/impl/topic_subscriptions.cpp
+++ b/src/protocol/gossip/impl/topic_subscriptions.cpp
@@ -39,7 +39,8 @@ namespace libp2p::protocol::gossip {
         log_(log) {}
 
   bool TopicSubscriptions::empty() const {
-    return (not self_subscribed_) && (fanout_period_ends_ == 0)
+    return (not self_subscribed_)
+        && (fanout_period_ends_ == std::chrono::milliseconds::zero())
         && subscribed_peers_.empty() && mesh_peers_.empty();
   }
 
@@ -50,8 +51,8 @@ namespace libp2p::protocol::gossip {
 
     if (is_published_locally) {
       fanout_period_ends_ = now + config_.seen_cache_lifetime_msec;
-      log_.debug("setting fanout period for {}, {}->{}", topic_, now,
-                 fanout_period_ends_);
+      log_.debug("setting fanout period for {}, {}->{}", topic_, now.count(),
+                 fanout_period_ends_.count());
     }
 
     auto origin = peerFrom(*msg);
@@ -94,7 +95,6 @@ namespace libp2p::protocol::gossip {
       if (sz < config_.D_min) {
         auto peers = subscribed_peers_.selectRandomPeers(config_.D_min - sz);
         for (auto &p : peers) {
-
           auto it = dont_bother_until_.find(p);
           if (it != dont_bother_until_.end()) {
             if (it->second < now) {
@@ -118,8 +118,9 @@ namespace libp2p::protocol::gossip {
 
     // fanout ends some time after this host ends publishing to the topic,
     // to save space and traffic
-    if (fanout_period_ends_ != 0 && fanout_period_ends_ < now) {
-      fanout_period_ends_ = 0;
+    if (fanout_period_ends_ != Time::zero()
+        && fanout_period_ends_ < now) {
+      fanout_period_ends_ = Time::zero();
       log_.debug("fanout period reset for {}", topic_);
     }
 
@@ -196,7 +197,7 @@ namespace libp2p::protocol::gossip {
     mesh_peers_.erase(p->peer_id);
     if (p->subscribed_to.count(topic_) != 0) {
       subscribed_peers_.insert(p);
-      dont_bother_until_.insert({ p, dont_bother_until });
+      dont_bother_until_.insert({p, dont_bother_until});
     }
   }
 

--- a/test/libp2p/protocol/gossip/gossip_structures_test.cpp
+++ b/test/libp2p/protocol/gossip/gossip_structures_test.cpp
@@ -156,11 +156,11 @@ TEST(Gossip, PeerSet) {
  * @then We see that all messages are both inserted and expired properly
  */
 TEST(Gossip, MessageCache) {
-  constexpr g::Time msg_lifetime = 20;
-  constexpr g::Time timer_interval = msg_lifetime / 2;
+  constexpr g::Time msg_lifetime {20};
+  constexpr g::Time timer_interval {msg_lifetime / 2};
 
-  g::Time current_time = 1234567890000ull;  // typically timestamp
-  g::Time stop_time = current_time + 400;
+  g::Time current_time {1234567890000ll};  // typically timestamp
+  g::Time stop_time = current_time + g::Time{400};
   auto clock = [&current_time]() -> g::Time { return current_time; };
 
   // 1. Create the cache
@@ -191,11 +191,11 @@ TEST(Gossip, MessageCache) {
 
   for (; current_time <= stop_time; ++current_time) {
     insertMessage(topic_1);
-    if (current_time % 2 == 1)
+    if (current_time.count() % 2 == 1)
       insertMessage(topic_2);
-    if (current_time % timer_interval == 0)
+    if (current_time.count() % timer_interval.count() == 0)
       cache.shift();
-    if (current_time % (timer_interval * 10) == 0) {
+    if (current_time.count() % (timer_interval.count() * 10) == 0) {
       for (auto it = inserted_messages.rbegin(); it != inserted_messages.rend();
            ++it) {
         auto msg = cache.getMessage(it->second);


### PR DESCRIPTION
Removing non actual peer information from gossip instances.
This self-cleanup is needed because some nodes use ephemeral peer ids