### PR TITLE
p2p_logger: remove already propagated dependency on yaml-cpp

### DIFF
--- a/src/log/CMakeLists.txt
+++ b/src/log/CMakeLists.txt
@@ -11,5 +11,4 @@ target_link_libraries(p2p_logger
     soralog::soralog
     soralog::fallback_configurator
     soralog::configurator_yaml
-    yaml-cpp::yaml-cpp
     )


### PR DESCRIPTION
This remove the unnecessary dependency on yaml-cpp, as it is already declared as an INTERFACE dependency of `soralog::configurator_yaml` in the CMake package config of soralog.