### PR TITLE
tests: add missing p2p_cares dependency to network injector test

### DIFF
--- a/test/libp2p/injector/CMakeLists.txt
+++ b/test/libp2p/injector/CMakeLists.txt
@@ -7,6 +7,7 @@ addtest(network_injector_test
 target_link_libraries(network_injector_test
     Boost::Boost.DI
     p2p_default_network
+    p2p_cares
     )
 
 


### PR DESCRIPTION
Because `p2p_cares` is not part of `p2p_default_network`, but used in the network injector, testsuite compilation currently fails for me with:
```
In file included from /build/source/include/libp2p/network/impl/dnsaddr_resolver_impl.hpp:15,
                 from /build/source/include/libp2p/injector/network_injector.hpp:26,
                 from /build/source/test/libp2p/injector/network_injector_test.cpp:6:
/build/source/include/libp2p/network/cares/cares.hpp:17:10: fatal error: ares.h: No such file or directory
   17 | #include <ares.h>
      |          ^~~~~~~~
```

This PR fixes the issue for me.