### PR TITLE
Provide default logger group explicitly

### DIFF
--- a/cmake/Hunter/config.cmake
+++ b/cmake/Hunter/config.cmake
@@ -14,3 +14,10 @@
 #     SHA1 1234567890abcdef1234567890abcdef12345678
 #     CMAKE_ARGS "CMAKE_VARIABLE=value"
 # )
+
+hunter_config(soralog
+    URL  "https://github.com/xDimon/soralog/archive/8fbddeef627eeb0456910ba92e89a5b4d9cd75ed.tar.gz"
+    SHA1 "98fa62ef43753ad80b2d64756aaa6fa6a49625c1"
+    CMAKE_ARGS TESTING=OFF EXAMPLES=OFF EXPOSE_MOCKS=ON
+    KEEP_PACKAGE_SOURCES
+    )

--- a/example/01-echo/libp2p_echo_client.cpp
+++ b/example/01-echo/libp2p_echo_client.cpp
@@ -63,7 +63,11 @@ int main(int argc, char *argv[]) {
 
   // prepare log system
   auto logging_system = std::make_shared<soralog::LoggingSystem>(
-      std::make_shared<libp2p::log::Configurator>(logger_config));
+      std::make_shared<soralog::ConfiguratorFromYAML>(
+          // Original LibP2P logging config
+          std::make_shared<libp2p::log::Configurator>(),
+          // Additional logging config for application
+          logger_config));
   auto r = logging_system->configure();
   if (not r.message.empty()) {
     (r.has_error ? std::cerr : std::cout) << r.message << std::endl;
@@ -74,9 +78,9 @@ int main(int argc, char *argv[]) {
 
   libp2p::log::setLoggingSystem(logging_system);
   if (std::getenv("TRACE_DEBUG") != nullptr) {
-    libp2p::log::setLevelOfGroup("*", soralog::Level::TRACE);
+    libp2p::log::setLevelOfGroup("main", soralog::Level::TRACE);
   } else {
-    libp2p::log::setLevelOfGroup("*", soralog::Level::ERROR);
+    libp2p::log::setLevelOfGroup("main", soralog::Level::ERROR);
   }
 
   // create Echo protocol object - it implement the logic of both server and

--- a/example/01-echo/libp2p_echo_server.cpp
+++ b/example/01-echo/libp2p_echo_server.cpp
@@ -11,9 +11,9 @@
 #include <libp2p/common/literals.hpp>
 #include <libp2p/host/basic_host.hpp>
 #include <libp2p/injector/host_injector.hpp>
-#include <libp2p/muxer/muxed_connection_config.hpp>
 #include <libp2p/log/configurator.hpp>
 #include <libp2p/log/logger.hpp>
+#include <libp2p/muxer/muxed_connection_config.hpp>
 #include <libp2p/protocol/echo.hpp>
 #include <libp2p/security/noise.hpp>
 #include <libp2p/security/plaintext.hpp>
@@ -78,7 +78,11 @@ int main(int argc, char **argv) {
 
   // prepare log system
   auto logging_system = std::make_shared<soralog::LoggingSystem>(
-      std::make_shared<libp2p::log::Configurator>(logger_config));
+      std::make_shared<soralog::ConfiguratorFromYAML>(
+          // Original LibP2P logging config
+          std::make_shared<libp2p::log::Configurator>(),
+          // Additional logging config for application
+          logger_config));
   auto r = logging_system->configure();
   if (not r.message.empty()) {
     (r.has_error ? std::cerr : std::cout) << r.message << std::endl;
@@ -89,9 +93,9 @@ int main(int argc, char **argv) {
 
   libp2p::log::setLoggingSystem(logging_system);
   if (std::getenv("TRACE_DEBUG") != nullptr) {
-    libp2p::log::setLevelOfGroup("*", soralog::Level::TRACE);
+    libp2p::log::setLevelOfGroup("main", soralog::Level::TRACE);
   } else {
-    libp2p::log::setLevelOfGroup("*", soralog::Level::ERROR);
+    libp2p::log::setLevelOfGroup("main", soralog::Level::ERROR);
   }
 
   // resulting PeerId should be

--- a/example/02-kademlia/rendezvous_chat.cpp
+++ b/example/02-kademlia/rendezvous_chat.cpp
@@ -42,7 +42,8 @@ class Session : public std::enable_shared_from_this<Session> {
     }
 
     stream_->readSome(
-        gsl::span(incoming_->data(), incoming_->size()), incoming_->size(),
+        gsl::span(incoming_->data(), incoming_->data() + incoming_->size()),
+        incoming_->size(),
         [self = shared_from_this()](libp2p::outcome::result<size_t> result) {
           if (not result) {
             self->close();
@@ -51,8 +52,8 @@ class Session : public std::enable_shared_from_this<Session> {
             return;
           }
           std::cout << self->stream_->remotePeerId().value().toBase58() << " > "
-                    << std::string(self->incoming_->begin(),
-                                   self->incoming_->begin() + result.value());
+                    << std::string(self->incoming_->data(),
+                                   self->incoming_->data() + result.value());
           std::cout.flush();
           self->read();
         });
@@ -66,7 +67,8 @@ class Session : public std::enable_shared_from_this<Session> {
     }
 
     stream_->write(
-        gsl::span(buffer->data(), buffer->size()), buffer->size(),
+        gsl::span(buffer->data(), buffer->data() + buffer->size()),
+        buffer->size(),
         [self = shared_from_this(),
          buffer](libp2p::outcome::result<size_t> result) {
           if (not result) {
@@ -76,8 +78,8 @@ class Session : public std::enable_shared_from_this<Session> {
             return;
           }
           std::cout << self->stream_->remotePeerId().value().toBase58() << " < "
-                    << std::string(buffer->begin(),
-                                   buffer->begin() + result.value());
+                    << std::string(buffer->data(),
+                                   buffer->data() + result.value());
           std::cout.flush();
         });
     return true;

--- a/example/02-kademlia/rendezvous_chat.cpp
+++ b/example/02-kademlia/rendezvous_chat.cpp
@@ -42,7 +42,7 @@ class Session : public std::enable_shared_from_this<Session> {
     }
 
     stream_->readSome(
-        gsl::span(incoming_->data(), incoming_->data() + incoming_->size()),
+        gsl::span(incoming_->data(), static_cast<ssize_t>(incoming_->size())),
         incoming_->size(),
         [self = shared_from_this()](libp2p::outcome::result<size_t> result) {
           if (not result) {
@@ -52,8 +52,9 @@ class Session : public std::enable_shared_from_this<Session> {
             return;
           }
           std::cout << self->stream_->remotePeerId().value().toBase58() << " > "
-                    << std::string(self->incoming_->data(),
-                                   self->incoming_->data() + result.value());
+                    << std::string(self->incoming_->begin(),
+                                   self->incoming_->begin()
+                                       + static_cast<ssize_t>(result.value()));
           std::cout.flush();
           self->read();
         });
@@ -67,7 +68,7 @@ class Session : public std::enable_shared_from_this<Session> {
     }
 
     stream_->write(
-        gsl::span(buffer->data(), buffer->data() + buffer->size()),
+        gsl::span(buffer->data(), static_cast<ssize_t>(buffer->size())),
         buffer->size(),
         [self = shared_from_this(),
          buffer](libp2p::outcome::result<size_t> result) {
@@ -78,8 +79,9 @@ class Session : public std::enable_shared_from_this<Session> {
             return;
           }
           std::cout << self->stream_->remotePeerId().value().toBase58() << " < "
-                    << std::string(buffer->data(),
-                                   buffer->data() + result.value());
+                    << std::string(buffer->begin(),
+                                   buffer->begin()
+                                       + static_cast<ssize_t>(result.value()));
           std::cout.flush();
         });
     return true;

--- a/example/02-kademlia/rendezvous_chat.cpp
+++ b/example/02-kademlia/rendezvous_chat.cpp
@@ -175,7 +175,11 @@ groups:
 int main(int argc, char *argv[]) {
   // prepare log system
   auto logging_system = std::make_shared<soralog::LoggingSystem>(
-      std::make_shared<libp2p::log::Configurator>(logger_config));
+      std::make_shared<soralog::ConfiguratorFromYAML>(
+          // Original LibP2P logging config
+          std::make_shared<libp2p::log::Configurator>(),
+          // Additional logging config for application
+          logger_config));
   auto r = logging_system->configure();
   if (not r.message.empty()) {
     (r.has_error ? std::cerr : std::cout) << r.message << std::endl;
@@ -186,9 +190,9 @@ int main(int argc, char *argv[]) {
 
   libp2p::log::setLoggingSystem(logging_system);
   if (std::getenv("TRACE_DEBUG") != nullptr) {
-    libp2p::log::setLevelOfGroup("*", soralog::Level::TRACE);
+    libp2p::log::setLevelOfGroup("main", soralog::Level::TRACE);
   } else {
-    libp2p::log::setLevelOfGroup("*", soralog::Level::ERROR);
+    libp2p::log::setLevelOfGroup("main", soralog::Level::ERROR);
   }
 
   // resulting PeerId should be

--- a/example/03-gossip/gossip_chat_example.cpp
+++ b/example/03-gossip/gossip_chat_example.cpp
@@ -9,8 +9,8 @@
 #include <boost/program_options.hpp>
 
 #include <libp2p/injector/host_injector.hpp>
-#include <libp2p/protocol/gossip/gossip.hpp>
 #include <libp2p/log/configurator.hpp>
+#include <libp2p/protocol/gossip/gossip.hpp>
 
 #include "console_async_reader.hpp"
 #include "utility.hpp"
@@ -60,7 +60,11 @@ int main(int argc, char *argv[]) {
 
   // prepare log system
   auto logging_system = std::make_shared<soralog::LoggingSystem>(
-      std::make_shared<libp2p::log::Configurator>(logger_config));
+      std::make_shared<soralog::ConfiguratorFromYAML>(
+          // Original LibP2P logging config
+          std::make_shared<libp2p::log::Configurator>(),
+          // Additional logging config for application
+          logger_config));
   auto r = logging_system->configure();
   if (not r.message.empty()) {
     (r.has_error ? std::cerr : std::cout) << r.message << std::endl;
@@ -71,9 +75,9 @@ int main(int argc, char *argv[]) {
 
   libp2p::log::setLoggingSystem(logging_system);
   if (std::getenv("TRACE_DEBUG") != nullptr) {
-    libp2p::log::setLevelOfGroup("*", soralog::Level::TRACE);
+    libp2p::log::setLevelOfGroup("main", soralog::Level::TRACE);
   } else {
-    libp2p::log::setLevelOfGroup("*", soralog::Level::ERROR);
+    libp2p::log::setLevelOfGroup("main", soralog::Level::ERROR);
   }
 
   // overriding default config to see local messages as well (echo mode)

--- a/example/03-gossip/utility.cpp
+++ b/example/03-gossip/utility.cpp
@@ -32,16 +32,16 @@ namespace libp2p::protocol::example::utility {
   void setupLoggers(char level) {
     switch (level) {
       case 'e':
-        libp2p::log::setLevelOfGroup("*", libp2p::log::Level::ERROR);
+        libp2p::log::setLevelOfGroup("main", libp2p::log::Level::ERROR);
         break;
       case 'w':
-        libp2p::log::setLevelOfGroup("*", libp2p::log::Level::WARN);
+        libp2p::log::setLevelOfGroup("main", libp2p::log::Level::WARN);
         break;
       case 'd':
-        libp2p::log::setLevelOfGroup("*", libp2p::log::Level::DEBUG);
+        libp2p::log::setLevelOfGroup("main", libp2p::log::Level::DEBUG);
         break;
       case 't':
-        libp2p::log::setLevelOfGroup("*", libp2p::log::Level::TRACE);
+        libp2p::log::setLevelOfGroup("main", libp2p::log::Level::TRACE);
         break;
       default:
         break;

--- a/example/04-dnstxt/ares_resolver.cpp
+++ b/example/04-dnstxt/ares_resolver.cpp
@@ -32,7 +32,11 @@ groups:
 int main(int argc, char *argv[]) {
   // prepare log system
   auto logging_system = std::make_shared<soralog::LoggingSystem>(
-      std::make_shared<libp2p::log::Configurator>(logger_config));
+      std::make_shared<soralog::ConfiguratorFromYAML>(
+          // Original LibP2P logging config
+          std::make_shared<libp2p::log::Configurator>(),
+          // Additional logging config for application
+          logger_config));
   auto r = logging_system->configure();
   if (not r.message.empty()) {
     (r.has_error ? std::cerr : std::cout) << r.message << std::endl;
@@ -43,9 +47,9 @@ int main(int argc, char *argv[]) {
 
   libp2p::log::setLoggingSystem(logging_system);
   if (std::getenv("TRACE_DEBUG") != nullptr) {
-    libp2p::log::setLevelOfGroup("*", soralog::Level::TRACE);
+    libp2p::log::setLevelOfGroup("main", soralog::Level::TRACE);
   } else {
-    libp2p::log::setLevelOfGroup("*", soralog::Level::ERROR);
+    libp2p::log::setLevelOfGroup("main", soralog::Level::ERROR);
   }
 
   // create a default Host via an injector

--- a/include/libp2p/log/logger.hpp
+++ b/include/libp2p/log/logger.hpp
@@ -16,6 +16,8 @@ namespace libp2p::log {
   using Level = soralog::Level;
   using Logger = std::shared_ptr<soralog::Logger>;
 
+  inline const std::string defaultGroupName("libp2p");
+
   void setLoggingSystem(std::shared_ptr<soralog::LoggingSystem> logging_system);
 
   [[nodiscard]] Logger createLogger(const std::string &tag);

--- a/src/basic/scheduler/asio_scheduler_backend.cpp
+++ b/src/basic/scheduler/asio_scheduler_backend.cpp
@@ -36,7 +36,7 @@ namespace libp2p::basic {
 
     if (ec) {
       // this should never happen
-      auto log = log::createLogger("Scheduler", "*");
+      auto log = log::createLogger("Scheduler", "scheduler");
       log->critical("cannot set timer: {}", ec.message());
       boost::asio::detail::throw_error(ec, "setTimer");
     }

--- a/src/log/configurator.cpp
+++ b/src/log/configurator.cpp
@@ -39,6 +39,7 @@ groups:
           - name: tls
           - name: listener_manager
           - name: libp2p_debug
+          - name: scheduler
 # --------------- End of libp2p config ---------------)");
   }
 

--- a/src/log/logger.cpp
+++ b/src/log/logger.cpp
@@ -28,7 +28,7 @@ namespace libp2p::log {
   Logger createLogger(const std::string &tag) {
     ensure_loger_system_is_initialized();
     return std::dynamic_pointer_cast<soralog::LoggerFactory>(logging_system_)
-        ->getLogger(tag, "*");
+        ->getLogger(tag, defaultGroupName);
   }
 
   Logger createLogger(const std::string &tag, const std::string &group) {

--- a/test/testutil/prepare_loggers.hpp
+++ b/test/testutil/prepare_loggers.hpp
@@ -46,7 +46,6 @@ groups:
               std::make_shared<libp2p::log::Configurator>(),
               // Additional logging config for testing
               testing_log_config));
-
       auto r = logging_system->configure();
       if (r.has_error) {
         std::cerr << r.message << std::endl;
@@ -56,7 +55,7 @@ groups:
       libp2p::log::setLoggingSystem(logging_system);
     });
 
-    libp2p::log::setLevelOfGroup("*", level);
+    libp2p::log::setLevelOfGroup(libp2p::log::defaultGroupName, level);
   }
 
 }  // namespace testutil


### PR DESCRIPTION
Deprecate star-marked default group. PR provides explicitly defined default group (new soralog feature).

Signed-off-by: Dmitriy Khaustov aka xDimon <khaustov.dm@gmail.com>