### PR TITLE
multihash-and-fixes

### DIFF
--- a/include/libp2p/multi/multihash.hpp
+++ b/include/libp2p/multi/multihash.hpp
@@ -86,6 +86,11 @@ namespace libp2p::multi {
      */
     const Buffer &toBuffer() const;
 
+    /**
+     * @return Pre-calculated hash for std containers
+     */
+    size_t stdHash() const;
+
     bool operator==(const Multihash &other) const;
     bool operator!=(const Multihash &other) const;
     bool operator<(const Multihash &other) const;
@@ -110,9 +115,20 @@ namespace libp2p::multi {
      * Contains a one byte hash type, a one byte hash length, and the stored
      * hash itself
      */
-    std::vector<uint8_t> data_;
-    uint8_t hash_offset_{};  ///< size of non-hash data from the beginning
-    HashType type_;
+    struct Data {
+      // TODO(artem): move to small_vector<const uint8_t, some_size>
+      // as soon as toBuffer() -> span<const uint8_t> is acceptable
+      std::vector<uint8_t> bytes;
+      uint8_t hash_offset{};  ///< size of non-hash data from the beginning
+      HashType type;
+      size_t std_hash; ///< Hash for unordered containers
+
+      Data(HashType t, gsl::span<const uint8_t> h);
+    };
+
+    const Data& data() const;
+
+    std::shared_ptr<const Data> data_;
   };
 
 }  // namespace libp2p::multi
@@ -120,7 +136,9 @@ namespace libp2p::multi {
 namespace std {
   template <>
   struct hash<libp2p::multi::Multihash> {
-    size_t operator()(const libp2p::multi::Multihash &x) const;
+    size_t operator()(const libp2p::multi::Multihash &x) const {
+      return x.stdHash();
+    }
   };
 }  // namespace std
 

--- a/include/libp2p/multi/multihash.hpp
+++ b/include/libp2p/multi/multihash.hpp
@@ -24,6 +24,12 @@ namespace libp2p::multi {
    */
   class Multihash {
    public:
+    Multihash(const Multihash &other) = default;
+    Multihash &operator=(const Multihash &other) = default;
+    Multihash(Multihash &&other) noexcept = default;
+    Multihash &operator=(Multihash &&other) noexcept = default;
+    ~Multihash() = default;
+
     using Buffer = common::ByteArray;
 
     static constexpr uint8_t kMaxHashLength = 127;

--- a/src/multi/CMakeLists.txt
+++ b/src/multi/CMakeLists.txt
@@ -21,7 +21,7 @@ libp2p_add_library(p2p_multihash
     )
 target_link_libraries(p2p_multihash
     p2p_hexutil
-    p2p_uvarint
+    p2p_varint_prefix_reader
     Boost::boost
     )
 


### PR DESCRIPTION
1) Multihash has immutable shared_ptr<const Data> inside, including precalculated std::hash, allows for performance while copying, sharing, using as key in containers
2) UVarint stuff in Multihash creation changed to impl with no dynamic allocations
3) Kademlia's PeerRoutingTable fixed (bugs were detected while applying p.1)