### PR TITLE
Allow blocks finalization for Kagome project

### DIFF
--- a/src/connection/loopback_stream.cpp
+++ b/src/connection/loopback_stream.cpp
@@ -5,6 +5,8 @@
 
 #include <libp2p/connection/loopback_stream.hpp>
 
+#include <tuple>
+
 namespace libp2p::connection {
 
   namespace {
@@ -12,6 +14,13 @@ namespace libp2p::connection {
     void deferCallback(boost::asio::io_context &ctx,
                        std::weak_ptr<LoopbackStream> wptr, Callback cb,
                        Arg arg) {
+      cb(arg);
+      std::ignore = ctx;
+      std::ignore = wptr;
+      return;
+      // temporary workaround for kagome to fix blocks finalization
+
+
       // defers callback to the next event loop cycle,
       // cb will be called iff Loopbackstream is still exists
       boost::asio::post(


### PR DESCRIPTION
Signed-off-by: Igor Egorov <igor@soramitsu.co.jp>

The fix brings back immediate callback invocation for the case when read or write operation occurs on a loopback stream.

Addresses the issue https://github.com/soramitsu/kagome/issues/710

