### PR TITLE
Let varint reader propagate the error

### DIFF
--- a/include/libp2p/basic/varint_reader.hpp
+++ b/include/libp2p/basic/varint_reader.hpp
@@ -9,14 +9,17 @@
 #include <functional>
 #include <memory>
 
-#include <boost/optional.hpp>
-
 #include <libp2p/basic/readwriter.hpp>
 #include <libp2p/multi/uvarint.hpp>
+#include <libp2p/outcome/outcome.hpp>
 
 namespace libp2p::basic {
   class VarintReader {
    public:
+    enum class Error {
+      NO_VARINT = 1,
+    };
+
     /**
      * Read a varint from the connection
      * @param conn to be read from
@@ -25,15 +28,17 @@ namespace libp2p::basic {
      */
     static void readVarint(
         std::shared_ptr<ReadWriter> conn,
-        std::function<void(boost::optional<multi::UVarint>)> cb);
+        std::function<void(outcome::result<multi::UVarint>)> cb);
 
    private:
     static void readVarint(
         std::shared_ptr<ReadWriter> conn,
-        std::function<void(boost::optional<multi::UVarint>)> cb,
+        std::function<void(outcome::result<multi::UVarint>)> cb,
         uint8_t current_length,
         std::shared_ptr<std::vector<uint8_t>> varint_buf);
   };
 }  // namespace libp2p::basic
+
+OUTCOME_HPP_DECLARE_ERROR(libp2p::basic, VarintReader::Error);
 
 #endif  // LIBP2P_VARINT_READER_HPP

--- a/include/libp2p/protocol/kademlia/impl/session.hpp
+++ b/include/libp2p/protocol/kademlia/impl/session.hpp
@@ -49,7 +49,7 @@ namespace libp2p::protocol::kademlia {
     void close(outcome::result<void> = outcome::success());
 
    private:
-    void onLengthRead(boost::optional<multi::UVarint> varint_opt);
+    void onLengthRead(outcome::result<multi::UVarint> varint);
 
     void onMessageRead(outcome::result<size_t> res);
 

--- a/src/basic/message_read_writer_error.cpp
+++ b/src/basic/message_read_writer_error.cpp
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "../../include/libp2p/basic/message_read_writer_error.hpp"
+#include "libp2p/basic/message_read_writer_error.hpp"
 
 OUTCOME_CPP_DEFINE_CATEGORY(libp2p::basic, MessageReadWriterError, e) {
   using E = libp2p::basic::MessageReadWriterError;

--- a/src/basic/message_read_writer_uvarint.cpp
+++ b/src/basic/message_read_writer_uvarint.cpp
@@ -24,12 +24,12 @@ namespace libp2p::basic {
     VarintReader::readVarint(
         conn_,
         [self{shared_from_this()}, cb = std::move(cb)](
-            boost::optional<multi::UVarint> varint_opt) mutable {
-          if (!varint_opt) {
-            return cb(MessageReadWriterError::VARINT_EXPECTED);
+            outcome::result<multi::UVarint> varint_res) mutable {
+          if (varint_res.has_error()) {
+            return cb(varint_res.error());
           }
 
-          auto msg_len = varint_opt->toUInt64();
+          auto msg_len = varint_res.value().toUInt64();
           if (0 != msg_len) {
             auto buffer = std::make_shared<std::vector<uint8_t>>(msg_len, 0);
             self->conn_->read(
@@ -40,8 +40,9 @@ namespace libp2p::basic {
                   }
                   cb(std::move(buffer));
                 });
-          } else
+          } else {
             cb(ResultType{});
+          }
         });
   }
 

--- a/src/basic/varint_reader.cpp
+++ b/src/basic/varint_reader.cpp
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "../../include/libp2p/basic/varint_reader.hpp"
+#include "libp2p/basic/varint_reader.hpp"
 
 #include <vector>
 

--- a/src/basic/varint_reader.cpp
+++ b/src/basic/varint_reader.cpp
@@ -11,30 +11,41 @@ namespace {
   constexpr uint8_t kMaximumVarintLength = 9;  // taken from Go
 }
 
+OUTCOME_CPP_DEFINE_CATEGORY(libp2p::basic, VarintReader::Error, e) {
+  using E = libp2p::basic::VarintReader::Error;
+  switch (e) {
+    case E::NO_VARINT:
+      return "Input stream does not contain a varint value";
+  }
+  return "Unknown error";
+}
+
 namespace libp2p::basic {
   void VarintReader::readVarint(
       std::shared_ptr<ReadWriter> conn,
-      std::function<void(boost::optional<multi::UVarint>)> cb) {
+      std::function<void(outcome::result<multi::UVarint>)> cb) {
     readVarint(std::move(conn), std::move(cb), 0,
                std::make_shared<std::vector<uint8_t>>(kMaximumVarintLength, 0));
   }
 
   void VarintReader::readVarint(
       std::shared_ptr<ReadWriter> conn,
-      std::function<void(boost::optional<multi::UVarint>)> cb,
+      std::function<void(outcome::result<multi::UVarint>)> cb,
       uint8_t current_length,
       std::shared_ptr<std::vector<uint8_t>> varint_buf) {
     if (current_length > kMaximumVarintLength) {
       // TODO(107): Reentrancy here, defer callback
-      return cb(boost::none);
+      // to the moment we read more bytes than varint may contain and still no
+      // valid varint was parsed
+      return cb(Error::NO_VARINT);
     }
 
     // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
     conn->read(gsl::make_span(varint_buf->data() + current_length, 1), 1,
                [c = std::move(conn), cb = std::move(cb), current_length,
                 varint_buf](auto &&res) mutable {
-                 if (!res) {
-                   return cb(boost::none);
+                 if (not res.has_value()) {
+                   return cb(res.error());
                  }
 
                  auto varint_opt = multi::UVarint::create(

--- a/src/protocol/gossip/impl/stream.hpp
+++ b/src/protocol/gossip/impl/stream.hpp
@@ -45,7 +45,7 @@ namespace libp2p::protocol::gossip {
     void close();
 
    private:
-    void onLengthRead(boost::optional<multi::UVarint> varint_opt);
+    void onLengthRead(outcome::result<multi::UVarint> varint);
     void onMessageRead(outcome::result<size_t> res);
     void beginWrite(SharedBuffer buffer);
     void onMessageWritten(outcome::result<size_t> res);

--- a/src/protocol/kademlia/impl/session.cpp
+++ b/src/protocol/kademlia/impl/session.cpp
@@ -59,6 +59,7 @@ namespace libp2p::protocol::kademlia {
 
     ++writing_;
 
+    // NOLINTNEXTLINE(cppcoreguidelines-narrowing-conversions)
     stream_->write(gsl::span(buffer->data(), buffer->size()), buffer->size(),
                    [wp = weak_from_this(), buffer,
                     response_handler](outcome::result<size_t> result) {
@@ -115,6 +116,7 @@ namespace libp2p::protocol::kademlia {
     auto msg_len = varint.value().toUInt64();
     inner_buffer_.resize(msg_len);
 
+    // NOLINTNEXTLINE(cppcoreguidelines-narrowing-conversions)
     stream_->read(gsl::span(inner_buffer_.data(), inner_buffer_.size()),
                   msg_len, [wp = weak_from_this()](auto &&res) {
                     if (auto self = wp.lock()) {

--- a/test/mock/libp2p/basic/readwritecloser_mock.hpp
+++ b/test/mock/libp2p/basic/readwritecloser_mock.hpp
@@ -8,7 +8,7 @@
 
 #include <gmock/gmock.h>
 #include "common/hexutil.hpp"
-#include "include/libp2p/basic/readwritecloser.hpp"
+#include "libp2p/basic/readwritecloser.hpp"
 
 namespace libp2p::basic {
   class ReadWriteCloserMock : public ReadWriteCloser {


### PR DESCRIPTION
An error may happen about the network stream. Previously the error was silently substituted with the generic varint error. Now the actual error will be propagated to the calling code.