### PR TITLE
Remove hunter upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,9 +51,6 @@ jobs:
       env:
         CC: ${{ matrix.compiler.cc }}
         CXX: ${{ matrix.compiler.cxx }}
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # has to be included to access other secrets
-        GITHUB_HUNTER_USERNAME: ${{ secrets.GITHUB_HUNTER_USERNAME }}
-        GITHUB_HUNTER_TOKEN: ${{ secrets.GITHUB_HUNTER_TOKEN }}
       run: cmake . -GNinja -Bbuild
     - name: build
       run: cmake --build build -- -j4


### PR DESCRIPTION
Old github token to upload to [hunter binary cache](https://github.com/soramitsu/hunter-binary-cache) was expired, which causes problems on ci. To fix that we can remove tokens, which should disable upload