### PR TITLE
multihash-and-fixes - Updated

### DIFF
--- a/include/libp2p/multi/multihash.hpp
+++ b/include/libp2p/multi/multihash.hpp
@@ -86,6 +86,11 @@ namespace libp2p::multi {
      */
     const Buffer &toBuffer() const;
 
+    /**
+     * @return Pre-calculated hash for std containers
+     */
+    size_t stdHash() const;
+
     bool operator==(const Multihash &other) const;
     bool operator!=(const Multihash &other) const;
     bool operator<(const Multihash &other) const;
@@ -110,9 +115,20 @@ namespace libp2p::multi {
      * Contains a one byte hash type, a one byte hash length, and the stored
      * hash itself
      */
-    std::vector<uint8_t> data_;
-    uint8_t hash_offset_{};  ///< size of non-hash data from the beginning
-    HashType type_;
+    struct Data {
+      // TODO(artem): move to small_vector<const uint8_t, some_size>
+      // as soon as toBuffer() -> span<const uint8_t> is acceptable
+      std::vector<uint8_t> bytes;
+      uint8_t hash_offset{};  ///< size of non-hash data from the beginning
+      HashType type;
+      size_t std_hash; ///< Hash for unordered containers
+
+      Data(HashType t, gsl::span<const uint8_t> h);
+    };
+
+    const Data& data() const;
+
+    std::shared_ptr<const Data> data_;
   };
 
 }  // namespace libp2p::multi
@@ -120,7 +136,9 @@ namespace libp2p::multi {
 namespace std {
   template <>
   struct hash<libp2p::multi::Multihash> {
-    size_t operator()(const libp2p::multi::Multihash &x) const;
+    size_t operator()(const libp2p::multi::Multihash &x) const {
+      return x.stdHash();
+    }
   };
 }  // namespace std
 

--- a/include/libp2p/multi/multihash.hpp
+++ b/include/libp2p/multi/multihash.hpp
@@ -24,6 +24,12 @@ namespace libp2p::multi {
    */
   class Multihash {
    public:
+    Multihash(const Multihash &other) = default;
+    Multihash &operator=(const Multihash &other) = default;
+    Multihash(Multihash &&other) noexcept = default;
+    Multihash &operator=(Multihash &&other) noexcept = default;
+    ~Multihash() = default;
+
     using Buffer = common::ByteArray;
 
     static constexpr uint8_t kMaxHashLength = 127;

--- a/src/multi/CMakeLists.txt
+++ b/src/multi/CMakeLists.txt
@@ -21,7 +21,7 @@ libp2p_add_library(p2p_multihash
     )
 target_link_libraries(p2p_multihash
     p2p_hexutil
-    p2p_uvarint
+    p2p_varint_prefix_reader
     Boost::boost
     )
 

--- a/src/multi/multihash.cpp
+++ b/src/multi/multihash.cpp
@@ -6,16 +6,14 @@
 #include <libp2p/multi/multihash.hpp>
 
 #include <boost/container_hash/hash.hpp>
+#include <libp2p/basic/varint_prefix_reader.hpp>
 #include <libp2p/common/hexutil.hpp>
 #include <libp2p/common/types.hpp>
 #include <libp2p/log/logger.hpp>
-#include <libp2p/basic/varint_prefix_reader.hpp>
 
 using libp2p::common::ByteArray;
 using libp2p::common::hex_upper;
 using libp2p::common::unhex;
-
-#define THROW_IF_MOVED_OBJECT_ACCESSED 0
 
 OUTCOME_CPP_DEFINE_CATEGORY(libp2p::multi, Multihash::Error, e) {
   using E = libp2p::multi::Multihash::Error;
@@ -66,7 +64,7 @@ namespace libp2p::multi {
   }
 
   const Multihash::Data &Multihash::data() const {
-#if THROW_IF_MOVED_OBJECT_ACCESSED
+#if NDEBUG
     if (data_ == nullptr) {
       log::createLogger("Multihash")->critical("attempt to use moved object");
       throw std::runtime_error("attempt to use moved multihash");
@@ -111,7 +109,7 @@ namespace libp2p::multi {
       return Error::INPUT_TOO_SHORT;
     }
 
-    uint8_t length = b[0];
+    const uint8_t length = b[0];
     gsl::span<const uint8_t> hash = b.subspan(1);
 
     if (length == 0) {

--- a/src/protocol/kademlia/impl/peer_routing_table_impl.cpp
+++ b/src/protocol/kademlia/impl/peer_routing_table_impl.cpp
@@ -36,6 +36,103 @@ namespace {
 
 namespace libp2p::protocol::kademlia {
 
+  size_t Bucket::size() const {
+    return peers_.size();
+  }
+
+  void Bucket::append(const Bucket &bucket) {
+    peers_.insert(peers_.end(), bucket.peers_.begin(), bucket.peers_.end());
+  }
+
+  void Bucket::sort(const NodeId &node_id) {
+    XorDistanceComparator cmp(node_id);
+    peers_.sort(cmp);
+  }
+
+  auto Bucket::find(const peer::PeerId &p) const {
+    return std::find_if(peers_.begin(), peers_.end(),
+                        [&p](const auto &i) { return i.peer_id == p; });
+  }
+
+  bool Bucket::moveToFront(const PeerId &pid) {
+    auto it = find(pid);
+    if (it != peers_.end()) {
+      if (it != peers_.begin()) {
+        peers_.splice(peers_.begin(), peers_, it);
+      }
+      return false;
+    }
+    return true;
+  }
+
+  void Bucket::emplaceToFront(const PeerId &pid, bool is_replaceable) {
+    peers_.emplace(peers_.begin(), pid, is_replaceable);
+  }
+
+  boost::optional<PeerId> Bucket::removeReplaceableItem() {
+    boost::optional<PeerId> result;
+
+    for (auto it = peers_.rbegin(); it != peers_.rend(); ++it) {
+      if (it->is_replaceable) {
+        result = std::move(it->peer_id);
+        peers_.erase((++it).base());
+        break;
+      }
+    }
+
+    return result;
+  }
+
+  void Bucket::truncate(size_t limit) {
+    if (limit == 0) {
+      peers_.clear();
+    } else if (peers_.size() > limit) {
+      peers_.erase(std::next(peers_.begin(), static_cast<long>(limit)),
+                   peers_.end());
+    }
+  }
+
+  std::vector<peer::PeerId> Bucket::peerIds() const {
+    std::vector<peer::PeerId> peerIds;
+    peerIds.reserve(peers_.size());
+    std::transform(peers_.begin(), peers_.end(), std::back_inserter(peerIds),
+                   [](const auto &bpi) { return bpi.peer_id; });
+    return peerIds;
+  }
+
+  bool Bucket::contains(const peer::PeerId &p) const {
+    return find(p) != peers_.end();
+  }
+
+  bool Bucket::remove(const peer::PeerId &p) {
+    auto it = find(p);
+    if (it != peers_.end()) {
+      peers_.erase(it);
+      return true;
+    }
+
+    return false;
+  }
+
+  Bucket Bucket::split(size_t commonLenPrefix, const NodeId &target) {
+    Bucket b{};
+
+    std::list<BucketPeerInfo> new_peers;
+
+    while (!peers_.empty()) {
+      auto it = peers_.begin();
+      if (it->node_id.commonPrefixLen(target) > commonLenPrefix) {
+        b.peers_.splice(b.peers_.end(), peers_, it);
+      } else {
+        new_peers.splice(new_peers.end(), peers_, it);
+      }
+    }
+
+    peers_.swap(new_peers);
+
+    return b;
+  }
+
   PeerRoutingTableImpl::PeerRoutingTableImpl(
       const Config &config,
       std::shared_ptr<peer::IdentityManager> identity_manager,
@@ -93,7 +190,7 @@ namespace libp2p::protocol::kademlia {
   namespace {
     outcome::result<bool> replacePeer(Bucket &bucket, const peer::PeerId &pid,
                                       bool is_replaceable, event::Bus &bus) {
-      auto removed = bucket.removeReplaceableItem();
+      const auto removed = bucket.removeReplaceableItem();
       if (!removed.has_value()) {
         return PeerRoutingTableImpl::Error::PEER_REJECTED_NO_CAPACITY;
       }
@@ -177,7 +274,7 @@ namespace libp2p::protocol::kademlia {
 
   std::vector<peer::PeerId> PeerRoutingTableImpl::getAllPeers() const {
     std::vector<peer::PeerId> vec;
-    for (auto &bucket : buckets_) {
+    for (const auto &bucket : buckets_) {
       auto peer_ids = bucket.peerIds();
       vec.insert(vec.end(), peer_ids.begin(), peer_ids.end());
     }


### PR DESCRIPTION
Fixed #146 

Multihash has immutable shared_ptr inside, including precalculated std::hash, allows for performance while copying, sharing, using as key in containers
UVarint stuff in Multihash creation changed to impl with no dynamic allocations
Kademlia's PeerRoutingTable fixed (bugs were detected while applying p.1)