### PR TITLE
PeerContext is used after being deleted, keep shared pointer to it.

### DIFF
--- a/src/protocol/gossip/impl/connectivity.cpp
+++ b/src/protocol/gossip/impl/connectivity.cpp
@@ -50,9 +50,9 @@ namespace libp2p::protocol::gossip {
     // clang-format off
     on_stream_event_ =
         [this, self_wptr=weak_from_this()]
-            (const PeerContextPtr &from, outcome::result<Success> event) {
+            (PeerContextPtr from, outcome::result<Success> event) {
           if (self_wptr.expired()) return;
-          onStreamEvent(from, event);
+          onStreamEvent(std::move(from), event);
         };
 
     host_->setProtocolHandler(

--- a/src/protocol/gossip/impl/stream.hpp
+++ b/src/protocol/gossip/impl/stream.hpp
@@ -23,7 +23,7 @@ namespace libp2p::protocol::gossip {
   class Stream : public std::enable_shared_from_this<Stream> {
    public:
     /// Feedback interface to its owning object (i.e. pub-sub instance)
-    using Feedback = std::function<void(const PeerContextPtr &from,
+    using Feedback = std::function<void(PeerContextPtr from,
                                         outcome::result<Success> event)>;
 
     /// Ctor. N.B. Stream instance cannot live longer than its creators


### PR DESCRIPTION
ASAN found 'heap-use-after-free' in gossip ([link](https://pastebin.com/uBDG1dK8)).

There is circular dependency in `Stream` and `PeerContext`.
`Stream` is passed as a weak pointer and is not locked [here](https://github.com/libp2p/cpp-libp2p/blob/7c9d83bf0760a5f653d86ddbb00645414c61d4fc/src/protocol/gossip/impl/connectivity.cpp#L54) and `PeerContext` is passed as a const ref [here](https://github.com/libp2p/cpp-libp2p/blob/7c9d83bf0760a5f653d86ddbb00645414c61d4fc/src/protocol/gossip/impl/connectivity.cpp#L53).
So, after shared pointer to `Stream` is [reset](https://github.com/libp2p/cpp-libp2p/blob/7c9d83bf0760a5f653d86ddbb00645414c61d4fc/src/protocol/gossip/impl/connectivity.cpp#L84), the `Stream` and `PeerContext` are deleted and than the attempt to read [here](https://github.com/libp2p/cpp-libp2p/blob/7c9d83bf0760a5f653d86ddbb00645414c61d4fc/src/protocol/gossip/impl/connectivity.cpp#L87) is made.
This PR keeps shared pointer to `PeerContext`.