### PR TITLE
Supress clang-tidy warning

### DIFF
--- a/include/libp2p/multi/content_identifier.hpp
+++ b/include/libp2p/multi/content_identifier.hpp
@@ -34,8 +34,6 @@ namespace libp2p::multi {
     ContentIdentifier(Version version, MulticodecType::Code content_type,
                       Multihash content_address);
 
-    virtual ~ContentIdentifier() = default;
-
     /**
      * @param base is a human-readable multibase prefix
      * @returns human readable representation of the CID

--- a/include/libp2p/multi/content_identifier.hpp
+++ b/include/libp2p/multi/content_identifier.hpp
@@ -34,6 +34,8 @@ namespace libp2p::multi {
     ContentIdentifier(Version version, MulticodecType::Code content_type,
                       Multihash content_address);
 
+    virtual ~ContentIdentifier() = default;
+
     /**
      * @param base is a human-readable multibase prefix
      * @returns human readable representation of the CID

--- a/include/libp2p/outcome/outcome.hpp
+++ b/include/libp2p/outcome/outcome.hpp
@@ -10,7 +10,8 @@
 #include <boost/outcome/success_failure.hpp>
 #include <boost/outcome/try.hpp>
 
-#define OUTCOME_TRY(...) BOOST_OUTCOME_TRY(__VA_ARGS__)
+#define OUTCOME_TRY(...) \
+  BOOST_OUTCOME_TRY(__VA_ARGS__)  // NOLINT(bugprone-branch-clone)
 
 #include <libp2p/outcome/outcome-register.hpp>
 
@@ -31,7 +32,7 @@ namespace libp2p::outcome {
             class NoValuePolicy = policy::default_policy<R, S, void>>  //
   using result = basic_result<R, S, NoValuePolicy>;
 
-}  // namespace outcome
+}  // namespace libp2p::outcome
 
 // @see /docs/result.md
 


### PR DESCRIPTION
Supress clang-tidy warning: if with identical then and else branches in OUTCOME_TRY.

Signed-off-by: Alexey-N-Chernyshov <alexey.n.chernyshov@gmail.com>