### PR TITLE
sha

### DIFF
--- a/include/libp2p/crypto/hasher.hpp
+++ b/include/libp2p/crypto/hasher.hpp
@@ -41,9 +41,9 @@ namespace libp2p::crypto {
     virtual HashType hashType() const = 0;
 
     outcome::result<libp2p::common::ByteArray> digest() const {
-      libp2p::common::ByteArray result;
-      result.resize(digestSize());
-      OUTCOME_TRY(digestOut(result));
+      outcome::result<libp2p::common::ByteArray> result{outcome::success()};
+      result.value().resize(digestSize());
+      OUTCOME_TRY(digestOut(result.value()));
       return result;
     }
   };

--- a/include/libp2p/crypto/hasher.hpp
+++ b/include/libp2p/crypto/hasher.hpp
@@ -26,7 +26,7 @@ namespace libp2p::crypto {
      * Does not affect the internal state.
      * New data still could be fed via write method.
      */
-    virtual outcome::result<std::vector<uint8_t>> digest() = 0;
+    virtual outcome::result<void> digestOut(gsl::span<uint8_t> out) const = 0;
 
     /// resets the internal state
     virtual outcome::result<void> reset() = 0;
@@ -39,6 +39,13 @@ namespace libp2p::crypto {
 
     /// runtime identifiable hasher type
     virtual HashType hashType() const = 0;
+
+    outcome::result<libp2p::common::ByteArray> digest() const {
+      libp2p::common::ByteArray result;
+      result.resize(digestSize());
+      OUTCOME_TRY(digestOut(result));
+      return result;
+    }
   };
 }  // namespace libp2p::crypto
 

--- a/include/libp2p/crypto/hmac_provider/hmac_provider_ctr_impl.hpp
+++ b/include/libp2p/crypto/hmac_provider/hmac_provider_ctr_impl.hpp
@@ -20,7 +20,7 @@ namespace libp2p::crypto::hmac {
 
     outcome::result<void> write(gsl::span<const uint8_t> data) override;
 
-    outcome::result<std::vector<uint8_t>> digest() override;
+    outcome::result<void> digestOut(gsl::span<uint8_t> out) const override;
 
     outcome::result<void> reset() override;
 

--- a/include/libp2p/crypto/sha/sha256.hpp
+++ b/include/libp2p/crypto/sha/sha256.hpp
@@ -39,13 +39,6 @@ namespace libp2p::crypto {
   };
 
   /**
-   * Take a SHA-256 hash from string
-   * @param input to be hashed
-   * @return hashed bytes
-   */
-  [[deprecated]] libp2p::common::Hash256 sha256(std::string_view input);
-
-  /**
    * Take a SHA-256 hash from bytes
    * @param input to be hashed
    * @return hashed bytes

--- a/include/libp2p/crypto/sha/sha256.hpp
+++ b/include/libp2p/crypto/sha/sha256.hpp
@@ -43,7 +43,8 @@ namespace libp2p::crypto {
    * @param input to be hashed
    * @return hashed bytes
    */
-  [[deprecated]] libp2p::common::Hash256 sha256(gsl::span<const uint8_t> input);
+  outcome::result<libp2p::common::Hash256> sha256(
+      gsl::span<const uint8_t> input);
 }  // namespace libp2p::crypto
 
 #endif  // LIBP2P_SHA256_HPP

--- a/include/libp2p/crypto/sha/sha256.hpp
+++ b/include/libp2p/crypto/sha/sha256.hpp
@@ -21,7 +21,7 @@ namespace libp2p::crypto {
 
     outcome::result<void> write(gsl::span<const uint8_t> data) override;
 
-    outcome::result<std::vector<uint8_t>> digest() override;
+    outcome::result<void> digestOut(gsl::span<uint8_t> out) const override;
 
     outcome::result<void> reset() override;
 

--- a/include/libp2p/crypto/sha/sha512.hpp
+++ b/include/libp2p/crypto/sha/sha512.hpp
@@ -45,7 +45,8 @@ namespace libp2p::crypto {
    * @param input to be hashed
    * @return hashed bytes
    */
-  [[deprecated]] libp2p::common::Hash512 sha512(gsl::span<const uint8_t> input);
+  outcome::result<libp2p::common::Hash512> sha512(
+      gsl::span<const uint8_t> input);
 }  // namespace libp2p::crypto
 
 #endif  // LIBP2P_SHA512_HPP

--- a/include/libp2p/crypto/sha/sha512.hpp
+++ b/include/libp2p/crypto/sha/sha512.hpp
@@ -41,13 +41,6 @@ namespace libp2p::crypto {
   };
 
   /**
-   * Take a SHA-512 hash from string
-   * @param input to be hashed
-   * @return hashed bytes
-   */
-  [[deprecated]] libp2p::common::Hash512 sha512(std::string_view input);
-
-  /**
    * Take a SHA-512 hash from bytes
    * @param input to be hashed
    * @return hashed bytes

--- a/include/libp2p/crypto/sha/sha512.hpp
+++ b/include/libp2p/crypto/sha/sha512.hpp
@@ -23,7 +23,7 @@ namespace libp2p::crypto {
 
     outcome::result<void> write(gsl::span<const uint8_t> data) override;
 
-    outcome::result<std::vector<uint8_t>> digest() override;
+    outcome::result<void> digestOut(gsl::span<uint8_t> out) const override;
 
     outcome::result<void> reset() override;
 

--- a/include/libp2p/crypto/sha/sha512.hpp
+++ b/include/libp2p/crypto/sha/sha512.hpp
@@ -31,6 +31,8 @@ namespace libp2p::crypto {
 
     size_t blockSize() const override;
 
+    HashType hashType() const override;
+
    private:
     void sinkCtx();
 

--- a/include/libp2p/protocol/kademlia/impl/peer_routing_table_impl.hpp
+++ b/include/libp2p/protocol/kademlia/impl/peer_routing_table_impl.hpp
@@ -30,10 +30,7 @@ namespace libp2p::protocol::kademlia {
 
   struct XorDistanceComparator {
     explicit XorDistanceComparator(const peer::PeerId &from) {
-      crypto::Sha256 hash;
-      hash.write(from.toVector()).value();
-      memcpy(hfrom.data(), hash.digest().value().data(),
-             std::min<size_t>(hash.digestSize(), hfrom.size()));
+      hfrom = crypto::sha256(from.toVector()).value();
     }
 
     explicit XorDistanceComparator(const NodeId &from)

--- a/include/libp2p/protocol/kademlia/node_id.hpp
+++ b/include/libp2p/protocol/kademlia/node_id.hpp
@@ -7,8 +7,8 @@
 #define LIBP2P_PROTOCOL_KADEMLIA_NODEID
 
 #include <bitset>
-#include <cstring>
 #include <climits>
+#include <cstring>
 #include <gsl/span>
 #include <memory>
 #include <vector>
@@ -60,25 +60,15 @@ namespace libp2p::protocol::kademlia {
     }
 
     explicit NodeId(const peer::PeerId &pid) {
-      crypto::Sha256 hasher;
-      auto write_res = hasher.write(pid.toVector());
-      BOOST_ASSERT(write_res.has_value());
-      auto digest_res = hasher.digest();
+      auto digest_res = crypto::sha256(pid.toVector());
       BOOST_ASSERT(digest_res.has_value());
-      auto &hash = digest_res.value();
-
-      memcpy(data_.data(), hash.data(), std::min(hash.size(), data_.size()));
+      data_ = digest_res.value();
     }
 
     explicit NodeId(const ContentId &content_id) {
-      crypto::Sha256 hasher;
-      auto write_res = hasher.write(content_id.data);
-      BOOST_ASSERT(write_res.has_value());
-      auto digest_res = hasher.digest();
+      auto digest_res = crypto::sha256(content_id.data);
       BOOST_ASSERT(digest_res.has_value());
-      auto &hash = digest_res.value();
-
-      memcpy(data_.data(), hash.data(), std::min(hash.size(), data_.size()));
+      data_ = digest_res.value();
     }
 
     inline bool operator==(const NodeId &other) const {
@@ -118,7 +108,6 @@ namespace libp2p::protocol::kademlia {
    private:
     Hash256 data_;
   };
-
 
 }  // namespace libp2p::protocol::kademlia
 

--- a/include/libp2p/protocol/kademlia/node_id.hpp
+++ b/include/libp2p/protocol/kademlia/node_id.hpp
@@ -62,13 +62,13 @@ namespace libp2p::protocol::kademlia {
     explicit NodeId(const peer::PeerId &pid) {
       auto digest_res = crypto::sha256(pid.toVector());
       BOOST_ASSERT(digest_res.has_value());
-      data_ = digest_res.value();
+      data_ = std::move(digest_res.value());
     }
 
     explicit NodeId(const ContentId &content_id) {
       auto digest_res = crypto::sha256(content_id.data);
       BOOST_ASSERT(digest_res.has_value());
-      data_ = digest_res.value();
+      data_ = std::move(digest_res.value());
     }
 
     inline bool operator==(const NodeId &other) const {

--- a/include/libp2p/transport/tcp/tcp_connection.hpp
+++ b/include/libp2p/transport/tcp/tcp_connection.hpp
@@ -6,8 +6,6 @@
 #ifndef LIBP2P_TCP_CONNECTION_HPP
 #define LIBP2P_TCP_CONNECTION_HPP
 
-#define BOOST_ASIO_NO_DEPRECATED
-
 #include <atomic>
 #include <chrono>
 

--- a/include/libp2p/transport/tcp/tcp_transport.hpp
+++ b/include/libp2p/transport/tcp/tcp_transport.hpp
@@ -6,8 +6,6 @@
 #ifndef LIBP2P_TCP_TRANSPORT_HPP
 #define LIBP2P_TCP_TRANSPORT_HPP
 
-#define BOOST_ASIO_NO_DEPRECATED
-
 #include <boost/asio.hpp>
 #include <libp2p/transport/tcp/tcp_listener.hpp>
 #include <libp2p/transport/tcp/tcp_util.hpp>

--- a/src/crypto/ecdsa_provider/ecdsa_provider_impl.cpp
+++ b/src/crypto/ecdsa_provider/ecdsa_provider_impl.cpp
@@ -51,7 +51,7 @@ namespace libp2p::crypto::ecdsa {
 
   outcome::result<Signature> EcdsaProviderImpl::sign(
       gsl::span<const uint8_t> message, const PrivateKey &key) const {
-    auto digest = sha256(message);
+    OUTCOME_TRY(digest, sha256(message));
     OUTCOME_TRY(ec_key, convertBytesToEcKey(key, d2i_ECPrivateKey));
     OUTCOME_TRY(signature, GenerateEcSignature(digest, ec_key));
     return std::move(signature);
@@ -60,7 +60,7 @@ namespace libp2p::crypto::ecdsa {
   outcome::result<bool> EcdsaProviderImpl::verify(
       gsl::span<const uint8_t> message, const Signature &signature,
       const PublicKey &key) const {
-    auto digest = sha256(message);
+    OUTCOME_TRY(digest, sha256(message));
     OUTCOME_TRY(ec_key, convertBytesToEcKey(key, d2i_EC_PUBKEY));
     OUTCOME_TRY(signature_status, VerifyEcSignature(digest, signature, ec_key));
     return signature_status;

--- a/src/crypto/hmac_provider/hmac_provider_ctr_impl.cpp
+++ b/src/crypto/hmac_provider/hmac_provider_ctr_impl.cpp
@@ -40,7 +40,8 @@ namespace libp2p::crypto::hmac {
       return;
     }
     initialized_ = 1
-        == HMAC_Init_ex(hmac_ctx_, key_.data(), key_.size(), hash_st_, nullptr);
+        == HMAC_Init_ex(hmac_ctx_, key_.data(), static_cast<int>(key_.size()),
+                        hash_st_, nullptr);
   }
 
   HmacProviderCtrImpl::~HmacProviderCtrImpl() {
@@ -89,8 +90,8 @@ namespace libp2p::crypto::hmac {
     hmac_ctx_ = HMAC_CTX_new();
     if (nullptr == hmac_ctx_
         or 1
-            != HMAC_Init_ex(hmac_ctx_, key_.data(), key_.size(), hash_st_,
-                            nullptr)) {
+            != HMAC_Init_ex(hmac_ctx_, key_.data(),
+                            static_cast<int>(key_.size()), hash_st_, nullptr)) {
       return HmacProviderError::FAILED_INITIALIZE_CONTEXT;
     }
     initialized_ = true;

--- a/src/crypto/rsa_provider/rsa_provider_impl.cpp
+++ b/src/crypto/rsa_provider/rsa_provider_impl.cpp
@@ -104,7 +104,8 @@ namespace libp2p::crypto::rsa {
   outcome::result<PublicKey> RsaProviderImpl::derive(
       const PrivateKey &private_key) const {
     const unsigned char *data_pointer = private_key.data();
-    RSA *rsa = d2i_RSAPrivateKey(nullptr, &data_pointer, private_key.size());
+    RSA *rsa = d2i_RSAPrivateKey(nullptr, &data_pointer,
+                                 static_cast<long>(private_key.size()));
     if (nullptr == rsa) {
       return KeyGeneratorError::KEY_DERIVATION_FAILED;
     }
@@ -119,7 +120,8 @@ namespace libp2p::crypto::rsa {
       const PrivateKey &private_key) {
     const unsigned char *data_pointer = private_key.data();
     std::shared_ptr<RSA> rsa{
-        d2i_RSAPrivateKey(nullptr, &data_pointer, private_key.size()),
+        d2i_RSAPrivateKey(nullptr, &data_pointer,
+                          static_cast<long>(private_key.size())),
         RSA_free};
     if (nullptr == rsa) {
       return KeyValidatorError::INVALID_PRIVATE_KEY;
@@ -159,7 +161,8 @@ namespace libp2p::crypto::rsa {
     const uint8_t *bytes = input_key.data();
     std::shared_ptr<X509_PUBKEY> key{X509_PUBKEY_new(), X509_PUBKEY_free};
     X509_PUBKEY *key_ptr = key.get();
-    if (d2i_X509_PUBKEY(&key_ptr, &bytes, input_key.size()) == nullptr) {
+    if (d2i_X509_PUBKEY(&key_ptr, &bytes, static_cast<long>(input_key.size()))
+        == nullptr) {
       return KeyValidatorError::INVALID_PUBLIC_KEY;
     }
     return key;

--- a/src/crypto/rsa_provider/rsa_provider_impl.cpp
+++ b/src/crypto/rsa_provider/rsa_provider_impl.cpp
@@ -130,7 +130,7 @@ namespace libp2p::crypto::rsa {
   outcome::result<Signature> RsaProviderImpl::sign(
       gsl::span<const uint8_t> message, const PrivateKey &private_key) const {
     OUTCOME_TRY(rsa, rsaFromPrivateKey(private_key));
-    Hash256 digest = sha256(message);
+    OUTCOME_TRY(digest, sha256(message));
     Signature signature(RSA_size(rsa.get()));
     unsigned int signature_size = 0;
     if (1
@@ -148,7 +148,7 @@ namespace libp2p::crypto::rsa {
     OUTCOME_TRY(x509_key, RsaProviderImpl::getPublicKeyFromBytes(public_key));
     EVP_PKEY *key = X509_PUBKEY_get0(x509_key.get());
     std::unique_ptr<RSA, void (*)(RSA *)> rsa{EVP_PKEY_get1_RSA(key), RSA_free};
-    Hash256 digest = sha256(message);
+    OUTCOME_TRY(digest, sha256(message));
     int result = RSA_verify(NID_sha256, digest.data(), digest.size(),
                             signature.data(), signature.size(), rsa.get());
     return 1 == result;

--- a/src/crypto/secp256k1_provider/secp256k1_provider_impl.cpp
+++ b/src/crypto/secp256k1_provider/secp256k1_provider_impl.cpp
@@ -73,11 +73,12 @@ namespace libp2p::crypto::secp256k1 {
   Secp256k1ProviderImpl::bytesToPrivateKey(const PrivateKey &input) {
     std::shared_ptr<EC_KEY> key{EC_KEY_new_by_curve_name(NID_secp256k1),
                                 EC_KEY_free};
-    if (key.get() == nullptr) {
+    if (key == nullptr) {
       return KeyGeneratorError::INTERNAL_ERROR;
     }
     std::unique_ptr<BIGNUM, void (*)(BIGNUM *)> key_bignum{
-        BN_bin2bn(input.data(), input.size(), nullptr), BN_free};
+        BN_bin2bn(input.data(), static_cast<int>(input.size()), nullptr),
+        BN_free};
     if (key_bignum == nullptr) {
       return KeyGeneratorError::INTERNAL_ERROR;
     }
@@ -113,7 +114,8 @@ namespace libp2p::crypto::secp256k1 {
     }
     const uint8_t *public_key_ptr = input.data();
     EC_KEY *key_ptr = key.get();
-    key_ptr = o2i_ECPublicKey(&key_ptr, &public_key_ptr, input.size());
+    key_ptr = o2i_ECPublicKey(&key_ptr, &public_key_ptr,
+                              static_cast<long>(input.size()));
     if (key_ptr == nullptr) {
       return KeyGeneratorError::INTERNAL_ERROR;
     }

--- a/src/crypto/secp256k1_provider/secp256k1_provider_impl.cpp
+++ b/src/crypto/secp256k1_provider/secp256k1_provider_impl.cpp
@@ -54,7 +54,7 @@ namespace libp2p::crypto::secp256k1 {
 
   outcome::result<Signature> Secp256k1ProviderImpl::sign(
       gsl::span<const uint8_t> message, const PrivateKey &key) const {
-    auto digest = sha256(message);
+    OUTCOME_TRY(digest, sha256(message));
     OUTCOME_TRY(private_key, bytesToPrivateKey(key));
     OUTCOME_TRY(signature, GenerateEcSignature(digest, private_key));
     return std::move(signature);
@@ -63,7 +63,7 @@ namespace libp2p::crypto::secp256k1 {
   outcome::result<bool> Secp256k1ProviderImpl::verify(
       gsl::span<const uint8_t> message, const Signature &signature,
       const PublicKey &key) const {
-    auto digest = sha256(message);
+    OUTCOME_TRY(digest, sha256(message));
     OUTCOME_TRY(public_key, bytesToPublicKey(key));
     OUTCOME_TRY(result, VerifyEcSignature(digest, signature, public_key));
     return result;

--- a/src/crypto/sha/sha256.cpp
+++ b/src/crypto/sha/sha256.cpp
@@ -11,16 +11,6 @@
 #include <libp2p/crypto/error.hpp>
 
 namespace libp2p::crypto {
-  libp2p::common::Hash256 sha256(gsl::span<const uint8_t> input) {
-    libp2p::common::Hash256 out;
-    SHA256_CTX ctx;
-    SHA256_Init(&ctx);
-    SHA256_Update(&ctx, input.data(), input.size());
-    SHA256_Final(out.data(), &ctx);
-    // TODO(igor-egorov) FIL-67 Try to add checks for SHA-X return values
-    return out;
-  }
-
   Sha256::Sha256() {  // NOLINT
     initialized_ = 1 == SHA256_Init(&ctx_);
   }
@@ -81,5 +71,14 @@ namespace libp2p::crypto {
 
   HashType Sha256::hashType() const {
     return HashType::SHA256;
+  }
+
+  outcome::result<libp2p::common::Hash256> sha256(
+      gsl::span<const uint8_t> input) {
+    Sha256 sha;
+    OUTCOME_TRY(sha.write(input));
+    libp2p::common::Hash256 out;
+    OUTCOME_TRY(sha.digestOut(out));
+    return out;
   }
 }  // namespace libp2p::crypto

--- a/src/crypto/sha/sha256.cpp
+++ b/src/crypto/sha/sha256.cpp
@@ -77,8 +77,8 @@ namespace libp2p::crypto {
       gsl::span<const uint8_t> input) {
     Sha256 sha;
     OUTCOME_TRY(sha.write(input));
-    libp2p::common::Hash256 out;
-    OUTCOME_TRY(sha.digestOut(out));
-    return out;
+    outcome::result<libp2p::common::Hash256> result{outcome::success()};
+    OUTCOME_TRY(sha.digestOut(result.value()));
+    return result;
   }
 }  // namespace libp2p::crypto

--- a/src/crypto/sha/sha256.cpp
+++ b/src/crypto/sha/sha256.cpp
@@ -44,17 +44,18 @@ namespace libp2p::crypto {
     return outcome::success();
   }
 
-  outcome::result<std::vector<uint8_t>> Sha256::digest() {
+  outcome::result<void> Sha256::digestOut(gsl::span<uint8_t> out) const {
     if (not initialized_) {
       return HmacProviderError::FAILED_INITIALIZE_CONTEXT;
     }
+    if (out.size() != static_cast<ptrdiff_t>(digestSize())) {
+      return HmacProviderError::WRONG_DIGEST_SIZE;
+    }
     SHA256_CTX ctx = ctx_;
-    std::vector<uint8_t> result;
-    result.resize(digestSize());
-    if (1 != SHA256_Final(result.data(), &ctx)) {
+    if (1 != SHA256_Final(out.data(), &ctx)) {
       return HmacProviderError::FAILED_FINALIZE_DIGEST;
     }
-    return result;
+    return outcome::success();
   }
 
   outcome::result<void> Sha256::reset() {

--- a/src/crypto/sha/sha256.cpp
+++ b/src/crypto/sha/sha256.cpp
@@ -11,11 +11,6 @@
 #include <libp2p/crypto/error.hpp>
 
 namespace libp2p::crypto {
-  libp2p::common::Hash256 sha256(std::string_view input) {
-    std::vector<uint8_t> bytes{input.begin(), input.end()};
-    return sha256(bytes);
-  }
-
   libp2p::common::Hash256 sha256(gsl::span<const uint8_t> input) {
     libp2p::common::Hash256 out;
     SHA256_CTX ctx;

--- a/src/crypto/sha/sha512.cpp
+++ b/src/crypto/sha/sha512.cpp
@@ -29,17 +29,18 @@ namespace libp2p::crypto {
     return outcome::success();
   }
 
-  outcome::result<std::vector<uint8_t>> Sha512::digest() {
+  outcome::result<void> Sha512::digestOut(gsl::span<uint8_t> out) const {
     if (not initialized_) {
       return HmacProviderError::FAILED_INITIALIZE_CONTEXT;
     }
+    if (out.size() != static_cast<ptrdiff_t>(digestSize())) {
+      return HmacProviderError::WRONG_DIGEST_SIZE;
+    }
     SHA512_CTX ctx = ctx_;
-    std::vector<uint8_t> result;
-    result.resize(digestSize());
-    if (1 != SHA512_Final(result.data(), &ctx)) {
+    if (1 != SHA512_Final(out.data(), &ctx)) {
       return HmacProviderError::FAILED_FINALIZE_DIGEST;
     }
-    return result;
+    return outcome::success();
   }
 
   outcome::result<void> Sha512::reset() {

--- a/src/crypto/sha/sha512.cpp
+++ b/src/crypto/sha/sha512.cpp
@@ -73,13 +73,12 @@ namespace libp2p::crypto {
     return HashType::SHA512;
   }
 
-  libp2p::common::Hash512 sha512(gsl::span<const uint8_t> input) {
+  outcome::result<libp2p::common::Hash512> sha512(
+      gsl::span<const uint8_t> input) {
+    Sha512 sha;
+    OUTCOME_TRY(sha.write(input));
     libp2p::common::Hash512 out;
-    SHA512_CTX ctx;
-    SHA512_Init(&ctx);
-    SHA512_Update(&ctx, input.data(), input.size());
-    SHA512_Final(out.data(), &ctx);
-    // TODO(igor-egorov) FIL-67 Try to add checks for SHA-X return values
+    OUTCOME_TRY(sha.digestOut(out));
     return out;
   }
 }  // namespace libp2p::crypto

--- a/src/crypto/sha/sha512.cpp
+++ b/src/crypto/sha/sha512.cpp
@@ -68,6 +68,10 @@ namespace libp2p::crypto {
     }
   }
 
+  HashType Sha512::hashType() const {
+    return HashType::SHA512;
+  }
+
   libp2p::common::Hash512 sha512(std::string_view input) {
     std::vector<uint8_t> bytes{input.begin(), input.end()};
     return sha512(bytes);

--- a/src/crypto/sha/sha512.cpp
+++ b/src/crypto/sha/sha512.cpp
@@ -73,11 +73,6 @@ namespace libp2p::crypto {
     return HashType::SHA512;
   }
 
-  libp2p::common::Hash512 sha512(std::string_view input) {
-    std::vector<uint8_t> bytes{input.begin(), input.end()};
-    return sha512(bytes);
-  }
-
   libp2p::common::Hash512 sha512(gsl::span<const uint8_t> input) {
     libp2p::common::Hash512 out;
     SHA512_CTX ctx;

--- a/src/crypto/sha/sha512.cpp
+++ b/src/crypto/sha/sha512.cpp
@@ -77,8 +77,8 @@ namespace libp2p::crypto {
       gsl::span<const uint8_t> input) {
     Sha512 sha;
     OUTCOME_TRY(sha.write(input));
-    libp2p::common::Hash512 out;
-    OUTCOME_TRY(sha.digestOut(out));
-    return out;
+    outcome::result<libp2p::common::Hash512> result{outcome::success()};
+    OUTCOME_TRY(sha.digestOut(result.value()));
+    return result;
   }
 }  // namespace libp2p::crypto

--- a/src/multi/content_identifier_codec.cpp
+++ b/src/multi/content_identifier_codec.cpp
@@ -78,12 +78,8 @@ namespace libp2p::multi {
 
   std::vector<uint8_t> ContentIdentifierCodec::encodeCIDV0(
       const void *byte_buffer, size_t sz) {
-    libp2p::crypto::Sha256 hasher;
-    auto write_res = hasher.write(gsl::span<const uint8_t>(
+    auto digest_res = crypto::sha256(gsl::make_span(
         reinterpret_cast<const uint8_t *>(byte_buffer), sz));  // NOLINT
-    BOOST_ASSERT(write_res.has_value());
-
-    auto digest_res = hasher.digest();
     BOOST_ASSERT(digest_res.has_value());
 
     auto &hash = digest_res.value();

--- a/src/multi/content_identifier_codec.cpp
+++ b/src/multi/content_identifier_codec.cpp
@@ -97,8 +97,8 @@ namespace libp2p::multi {
     std::vector<uint8_t> bytes;
     // Reserve space for CID version size + content-type size + multihash size
     bytes.reserve(1 + 1 + mhash.toBuffer().size());
-    bytes.push_back(1);  // CID version
-    bytes.push_back(static_cast<uint8_t>(content_type)); // Content-Type
+    bytes.push_back(1);                                   // CID version
+    bytes.push_back(static_cast<uint8_t>(content_type));  // Content-Type
     std::copy(mhash.toBuffer().begin(), mhash.toBuffer().end(),
               std::back_inserter(bytes));  // multihash data
     return bytes;
@@ -118,12 +118,13 @@ namespace libp2p::multi {
     auto version = version_opt.value().toUInt64();
     if (version == 1) {
       auto version_length = UVarint::calculateSize(bytes);
-      auto multicodec_opt = UVarint::create(bytes.subspan(version_length));
+      auto multicodec_opt = UVarint::create(
+          bytes.subspan(static_cast<ptrdiff_t>(version_length)));
       if (!multicodec_opt) {
         return DecodeError::EMPTY_MULTICODEC;
       }
-      auto multicodec_length =
-          UVarint::calculateSize(bytes.subspan(version_length));
+      auto multicodec_length = UVarint::calculateSize(
+          bytes.subspan(static_cast<ptrdiff_t>(version_length)));
       OUTCOME_TRY(hash,
                   Multihash::createFromBytes(
                       bytes.subspan(version_length + multicodec_length)));

--- a/src/muxer/yamux/yamux_stream.cpp
+++ b/src/muxer/yamux/yamux_stream.cpp
@@ -242,7 +242,8 @@ namespace libp2p::connection {
 
       assert(bytes_consumed > 0);
 
-      external_read_buffer_ = external_read_buffer_.subspan(bytes_consumed);
+      external_read_buffer_ =
+          external_read_buffer_.subspan(static_cast<ptrdiff_t>(bytes_consumed));
 
       read_completed = external_read_buffer_.empty();
       if (reading_some_) {
@@ -423,7 +424,7 @@ namespace libp2p::connection {
     // If something is still in read buffer, the client can consume these bytes
     auto bytes_available_now = internal_read_buffer_.size();
     if (bytes_available_now >= bytes || (some && bytes_available_now > 0)) {
-      out = out.first(bytes);
+      out = out.first(static_cast<ptrdiff_t>(bytes));
       size_t consumed = internal_read_buffer_.consume(out);
 
       assert(consumed > 0);
@@ -452,12 +453,13 @@ namespace libp2p::connection {
     external_read_buffer_ = out;
     read_message_size_ = bytes;
     reading_some_ = some;
-    external_read_buffer_ = external_read_buffer_.first(read_message_size_);
+    external_read_buffer_ =
+        external_read_buffer_.first(static_cast<ptrdiff_t>(read_message_size_));
 
     if (bytes_available_now > 0) {
       internal_read_buffer_.consume(external_read_buffer_);
-      external_read_buffer_ =
-          external_read_buffer_.subspan(bytes_available_now);
+      external_read_buffer_ = external_read_buffer_.subspan(
+          static_cast<ptrdiff_t>(bytes_available_now));
     }
   }
 
@@ -538,7 +540,8 @@ namespace libp2p::connection {
       return deferWriteCallback(Error::STREAM_WRITE_OVERFLOW, std::move(cb));
     }
 
-    write_queue_.enqueue(in.first(bytes), some, std::move(cb));
+    write_queue_.enqueue(in.first(static_cast<ptrdiff_t>(bytes)), some,
+                         std::move(cb));
     doWrite();
   }
 

--- a/src/muxer/yamux/yamux_stream.cpp
+++ b/src/muxer/yamux/yamux_stream.cpp
@@ -444,7 +444,7 @@ namespace libp2p::connection {
 
     if (!is_readable_) {
       // half closed
-      return deferReadCallback(Error::STREAM_NOT_READABLE, std::move(read_cb_));
+      return deferReadCallback(Error::STREAM_NOT_READABLE, std::move(cb));
     }
 
     is_reading_ = true;

--- a/src/peer/peer_id.cpp
+++ b/src/peer/peer_id.cpp
@@ -36,7 +36,7 @@ namespace libp2p::peer {
       algo = multi::identity;
       hash = key.key;
     } else {
-      auto shash = crypto::sha256(key.key);
+      OUTCOME_TRY(shash, crypto::sha256(key.key));
       hash = std::vector<uint8_t>{shash.begin(), shash.end()};
     }
 
@@ -81,7 +81,7 @@ namespace libp2p::peer {
     return encodeBase58(hash_.toBuffer());
   }
 
-  const std::vector<uint8_t>& PeerId::toVector() const {
+  const std::vector<uint8_t> &PeerId::toVector() const {
     return hash_.toBuffer();
   }
 

--- a/src/protocol/kademlia/impl/content_id.cpp
+++ b/src/protocol/kademlia/impl/content_id.cpp
@@ -17,13 +17,9 @@ namespace libp2p::protocol::kademlia {
       : data(multi::ContentIdentifierCodec::encodeCIDV0("", 0)) {}
 
   ContentId::ContentId(std::string_view str) {
-    libp2p::crypto::Sha256 hasher;
-    auto write_res = hasher.write(gsl::span<const uint8_t>(
+    auto digest_res = crypto::sha256(gsl::make_span(
         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
         reinterpret_cast<const uint8_t *>(str.data()), str.size()));
-    BOOST_ASSERT(write_res.has_value());
-
-    auto digest_res = hasher.digest();
     BOOST_ASSERT(digest_res.has_value());
 
     auto mhash_res = libp2p::multi::Multihash::create(

--- a/src/protocol/kademlia/impl/content_id.cpp
+++ b/src/protocol/kademlia/impl/content_id.cpp
@@ -19,7 +19,8 @@ namespace libp2p::protocol::kademlia {
   ContentId::ContentId(std::string_view str) {
     auto digest_res = crypto::sha256(gsl::make_span(
         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-        reinterpret_cast<const uint8_t *>(str.data()), str.size()));
+        reinterpret_cast<const uint8_t *>(str.data()),
+        static_cast<ptrdiff_t>(str.size())));
     BOOST_ASSERT(digest_res.has_value());
 
     auto mhash_res = libp2p::multi::Multihash::create(
@@ -36,7 +37,8 @@ namespace libp2p::protocol::kademlia {
   boost::optional<ContentId> ContentId::fromWire(std::string_view str) {
     gsl::span<const uint8_t> bytes(
         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-        reinterpret_cast<const uint8_t *>(str.data()), str.size());
+        reinterpret_cast<const uint8_t *>(str.data()),
+        static_cast<ptrdiff_t>(str.size()));
     return fromWire(bytes);
   }
 

--- a/src/security/secio/secio_dialer.cpp
+++ b/src/security/secio/secio_dialer.cpp
@@ -84,8 +84,8 @@ namespace {
 namespace libp2p::security::secio {
   Dialer::Dialer(std::shared_ptr<connection::RawConnection> connection)
       : rw{std::make_shared<libp2p::basic::ProtobufMessageReadWriter>(
-            std::make_shared<libp2p::basic::MessageReadWriterBigEndian>(
-                std::move(connection)))} {}
+          std::make_shared<libp2p::basic::MessageReadWriterBigEndian>(
+              std::move(connection)))} {}
 
   void Dialer::storeLocalPeerProposalBytes(
       const std::shared_ptr<std::vector<uint8_t>> &bytes) {
@@ -193,8 +193,8 @@ namespace libp2p::security::secio {
     std::copy(remote.rand.begin(), remote.rand.end(),
               std::back_inserter(corpus2));
 
-    auto oh1{crypto::sha256(corpus1)};
-    auto oh2{crypto::sha256(corpus2)};
+    OUTCOME_TRY(oh1, crypto::sha256(corpus1));
+    OUTCOME_TRY(oh2, crypto::sha256(corpus2));
 
     if (oh1 == oh2) {
       return Error::PEER_COMMUNICATING_ITSELF;

--- a/test/libp2p/peer/peer_id_test.cpp
+++ b/test/libp2p/peer/peer_id_test.cpp
@@ -32,7 +32,7 @@ TEST_F(PeerIdTest, FromPubkeySuccess) {
   pubkey.type = Key::Type::RSA;
   pubkey.data = kBuffer;
 
-  auto hash = libp2p::crypto::sha256(pubkey.data);
+  auto hash = libp2p::crypto::sha256(pubkey.data).value();
   EXPECT_OUTCOME_TRUE(multihash,
                       Multihash::create(libp2p::multi::sha256,
                                         Buffer{hash.begin(), hash.end()}))


### PR DESCRIPTION
- remove `[[deprecated]]` from `sha256()`/`sha512()`.
- `sha256()`/`sha512()` return outcome.
- remove `sha256()`/`sha512()` from string (bytes-chars conversion is commonly used, should make separate convertion functions).
- `Hasher::digestOut()` that doesn't allocate (result vector).
- change `Sha256{}` usages with single `write()` to`sha256()`.
- clang-tidy, clang-format.

- #166.
- fix wrong callback in yamux_stream.hpp.