### PR TITLE
Fix Dialer

### DIFF
--- a/include/libp2p/network/impl/dialer_impl.hpp
+++ b/include/libp2p/network/impl/dialer_impl.hpp
@@ -6,6 +6,9 @@
 #ifndef LIBP2P_DIALER_IMPL_HPP
 #define LIBP2P_DIALER_IMPL_HPP
 
+#include <set>
+#include <unordered_map>
+
 #include <libp2p/basic/scheduler.hpp>
 #include <libp2p/network/connection_manager.hpp>
 #include <libp2p/network/dialer.hpp>
@@ -39,11 +42,46 @@ namespace libp2p::network {
                    StreamResultFunc cb) override;
 
    private:
+    // A context to handle an intermediary state of the peer we are dialing to
+    // but the connection is not yet established
+    struct DialCtx {
+      /// Known and scheduled addresses to try to dial via
+      std::set<multi::Multiaddress> addresses;
+
+      /// Timeout for a single connection attempt
+      std::chrono::milliseconds timeout;
+
+      /// Addresses we already tried, but no connection was established
+      std::set<multi::Multiaddress> tried_addresses;
+
+      /// Callbacks for all who requested a connection to the peer
+      std::vector<Dialer::DialResultFunc> callbacks;
+
+      /// Result temporary storage to propagate via callbacks
+      boost::optional<DialResult> result;
+      // ^ used when all connecting attempts failed and no more known peer
+      // addresses are left
+
+      // indicates that at least one attempt to dial was happened
+      // (at least one supported network transport was found and used)
+      bool dialled = false;
+    };
+
+    // Perform a single attempt to dial to the peer via the next known address
+    void rotate(const peer::PeerId &peer_id);
+
+    // Finalize dialing to the peer and propagate a given result to all re
+    void completeDial(const peer::PeerId &peer_id, const DialResult &result);
+
     std::shared_ptr<protocol_muxer::ProtocolMuxer> multiselect_;
     std::shared_ptr<TransportManager> tmgr_;
     std::shared_ptr<ConnectionManager> cmgr_;
     std::shared_ptr<ListenerManager> listener_;
     std::shared_ptr<basic::Scheduler> scheduler_;
+    log::Logger log_;
+
+    // peers we are currently dialing to
+    std::unordered_map<peer::PeerId, DialCtx> dialing_peers_;
   };
 
 }  // namespace libp2p::network

--- a/include/libp2p/network/impl/dialer_impl.hpp
+++ b/include/libp2p/network/impl/dialer_impl.hpp
@@ -72,7 +72,7 @@ namespace libp2p::network {
     void rotate(const peer::PeerId &peer_id);
 
     // Finalize dialing to the peer and propagate a given result to all
-    // connection requestors
+    // connection requesters
     void completeDial(const peer::PeerId &peer_id, const DialResult &result);
 
     std::shared_ptr<protocol_muxer::ProtocolMuxer> multiselect_;

--- a/include/libp2p/network/impl/dialer_impl.hpp
+++ b/include/libp2p/network/impl/dialer_impl.hpp
@@ -18,7 +18,8 @@
 
 namespace libp2p::network {
 
-  class DialerImpl : public Dialer {
+  class DialerImpl : public Dialer,
+                     public std::enable_shared_from_this<DialerImpl> {
    public:
     ~DialerImpl() override = default;
 
@@ -70,7 +71,8 @@ namespace libp2p::network {
     // Perform a single attempt to dial to the peer via the next known address
     void rotate(const peer::PeerId &peer_id);
 
-    // Finalize dialing to the peer and propagate a given result to all re
+    // Finalize dialing to the peer and propagate a given result to all
+    // connection requestors
     void completeDial(const peer::PeerId &peer_id, const DialResult &result);
 
     std::shared_ptr<protocol_muxer::ProtocolMuxer> multiselect_;

--- a/include/libp2p/network/impl/network_impl.hpp
+++ b/include/libp2p/network/impl/network_impl.hpp
@@ -16,7 +16,7 @@ namespace libp2p::network {
     ~NetworkImpl() override = default;
 
     NetworkImpl(std::shared_ptr<ListenerManager> listener,
-                std::unique_ptr<Dialer> dialer,
+                std::shared_ptr<Dialer> dialer,
                 std::shared_ptr<ConnectionManager> cmgr);
 
     void closeConnections(const peer::PeerId &p) override;
@@ -29,7 +29,7 @@ namespace libp2p::network {
 
    private:
     std::shared_ptr<ListenerManager> listener_;
-    std::unique_ptr<Dialer> dialer_;
+    std::shared_ptr<Dialer> dialer_;
     std::shared_ptr<ConnectionManager> cmgr_;
   };
 

--- a/src/network/impl/network_impl.cpp
+++ b/src/network/impl/network_impl.cpp
@@ -24,7 +24,7 @@ namespace libp2p::network {
   }
 
   NetworkImpl::NetworkImpl(std::shared_ptr<ListenerManager> listener,
-                           std::unique_ptr<Dialer> dialer,
+                           std::shared_ptr<Dialer> dialer,
                            std::shared_ptr<ConnectionManager> cmgr)
       : listener_(std::move(listener)),
         dialer_(std::move(dialer)),

--- a/src/peer/address_repository/inmem_address_repository.cpp
+++ b/src/peer/address_repository/inmem_address_repository.cpp
@@ -99,8 +99,8 @@ namespace libp2p::peer {
 
     auto expires_at = Clock::now() + ttl;
     for (const auto &m : ma) {
-      auto [addr_it, added] = addresses.emplace(m, expires_at);
-      if (added) {
+      auto [addr_it, emplaced] = addresses.emplace(m, expires_at);
+      if (emplaced) {
         signal_added_(p, m);
         added = true;
       } else {


### PR DESCRIPTION
1. Make dialer open only one outgoing connection to a peer
2. Use sync version of conn->newStream in all cases, because the fully async one is broken and to be fixed later.

Required for kagome to speed up sync and peer discovery processes.