### PR TITLE
refactor noise read write

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -32,12 +32,18 @@ jobs:
         CC: clang
         CXX: clang++
       run: cmake . -GNinja -Bbuild-coverage -DCOVERAGE=ON -DEXAMPLES=OFF
+    - name: "build"
+      run: cmake --build build-coverage -- -j4
     - name: "build report"
       env:
         CTEST_OUTPUT_ON_FAILURE: 1
       run: cmake --build build-coverage --target ctest_coverage -- -j4
     - name: "upload"
-      uses: codecov/codecov-action@v1.2.1
+      uses: codecov/codecov-action@v2
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # has to be included to access other secrets
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        fail_ci_if_error: true
         files: build-coverage/ctest_coverage.xml
-        verbose: false
+        verbose: true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,9 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
   # TODO(warchant): add flags https://github.com/lefticus/cppbestpractices/blob/master/02-Use_the_Tools_Available.md#msvc
 endif ()
 
+if (COVERAGE)
+  include(cmake/coverage.cmake)
+endif ()
 if (CLANG_TIDY)
   include(cmake/clang-tidy.cmake)
 endif ()
@@ -109,7 +112,3 @@ if(TESTING OR COVERAGE)
   enable_testing()
   add_subdirectory(test)
 endif()
-
-if (COVERAGE)
-  include(cmake/coverage.cmake)
-endif ()

--- a/housekeeping/clang-tidy.sh
+++ b/housekeeping/clang-tidy.sh
@@ -23,7 +23,7 @@ cd $(dirname $0)/..
 FILES=$(get_files)
 
 CLANG_TIDY=$(which clang-tidy)
-RUN_CLANG_TIDY=$(which run-clang-tidy.py)
+RUN_CLANG_TIDY=$(which run-clang-tidy.py) || RUN_CLANG_TIDY=$(which run-clang-tidy)
 
 # filter compile_commands.json
 echo ${FILES} | python3 ./housekeeping/filter_compile_commands.py -p ${BUILD_DIR}

--- a/include/libp2p/common/span_size.hpp
+++ b/include/libp2p/common/span_size.hpp
@@ -1,0 +1,13 @@
+/**
+ * Copyright Soramitsu Co., Ltd. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <gsl/span>
+
+template <typename T = size_t>
+constexpr T spanSize(const gsl::span<const uint8_t> &span) {
+  return gsl::narrow<T>(span.size());
+}

--- a/include/libp2p/security/noise/noise_connection.hpp
+++ b/include/libp2p/security/noise/noise_connection.hpp
@@ -6,8 +6,6 @@
 #ifndef LIBP2P_INCLUDE_LIBP2P_SECURITY_NOISE_NOISE_CONNECTION_HPP
 #define LIBP2P_INCLUDE_LIBP2P_SECURITY_NOISE_NOISE_CONNECTION_HPP
 
-#include <list>
-
 #include <libp2p/connection/secure_connection.hpp>
 
 #include <libp2p/common/metrics/instance_count.hpp>
@@ -24,14 +22,6 @@ namespace libp2p::connection {
   class NoiseConnection : public SecureConnection,
                           public std::enable_shared_from_this<NoiseConnection> {
    public:
-    using BufferList = std::list<common::ByteArray>;
-
-    struct OperationContext {
-      size_t bytes_served;                /// written or read bytes count
-      const size_t total_bytes;           /// total size to process
-      BufferList::iterator write_buffer;  /// temporary data storage
-    };
-
     ~NoiseConnection() override = default;
 
     NoiseConnection(
@@ -75,16 +65,10 @@ namespace libp2p::connection {
     outcome::result<crypto::PublicKey> remotePublicKey() const override;
 
    private:
-    void read(gsl::span<uint8_t> out, size_t bytes, OperationContext ctx,
-              ReadCallbackFunc cb);
+    void readFull(gsl::span<uint8_t> out, size_t total, ReadCallbackFunc cb);
 
-    void readSome(gsl::span<uint8_t> out, size_t bytes, OperationContext ctx,
-                  ReadCallbackFunc cb);
-
-    void write(gsl::span<const uint8_t> in, size_t bytes, OperationContext ctx,
-               WriteCallbackFunc cb);
-
-    void eraseWriteBuffer(BufferList::iterator &iterator);
+    void writeFull(gsl::span<const uint8_t> in, size_t total,
+                   WriteCallbackFunc cb);
 
     std::shared_ptr<RawConnection> raw_connection_;
     crypto::PublicKey local_;
@@ -94,7 +78,7 @@ namespace libp2p::connection {
     std::shared_ptr<security::noise::CipherState> decoder_cs_;
     std::shared_ptr<common::ByteArray> frame_buffer_;
     std::shared_ptr<security::noise::InsecureReadWriter> framer_;
-    BufferList write_buffers_;
+    common::ByteArray writing_;
     log::Logger log_ = log::createLogger("NoiseConnection");
 
    public:


### PR DESCRIPTION
- simplify noise read write (reverts e13f051).
- fix noise write reported count.
- `spanSize` cast helper.
- fix clang-tidy ci.