### PR TITLE
Add interface for prehashed messages to ECDSA provider

### DIFF
--- a/include/libp2p/crypto/ecdsa_provider.hpp
+++ b/include/libp2p/crypto/ecdsa_provider.hpp
@@ -27,13 +27,22 @@ namespace libp2p::crypto::ecdsa {
     virtual outcome::result<PublicKey> derive(const PrivateKey &key) const = 0;
 
     /**
-     * @brief Create signature for a message
+     * @brief Create a signature for a message
      * @param message - data to signing
      * @param privateKey - key for signing
      * @return ECDSA signature or error code
      */
     virtual outcome::result<Signature> sign(gsl::span<const uint8_t> message,
                                             const PrivateKey &key) const = 0;
+
+    /**
+     * @brief Create a signature for already prehashed message
+     * @param message - prehashed message aka digest
+     * @param key - key for signing
+     * @return a signature or an error
+     */
+    virtual outcome::result<Signature> signPrehashed(
+        const PrehashedMessage &message, const PrivateKey &key) const = 0;
 
     /**
      * @brief Verify signature for a message
@@ -44,7 +53,18 @@ namespace libp2p::crypto::ecdsa {
      */
     virtual outcome::result<bool> verify(gsl::span<const uint8_t> message,
                                          const Signature &signature,
-                                         const PublicKey &publicKey) const = 0;
+                                         const PublicKey &public_key) const = 0;
+
+    /**
+     * @brief Verify message signature
+     * @param message - prehashed message aka digest
+     * @param signature - signature to verify
+     * @param public_key - a key to verify against
+     * @return true - when signature matches, false - otherwise
+     */
+    virtual outcome::result<bool> verifyPrehashed(
+        const PrehashedMessage &message, const Signature &signature,
+        const PublicKey &public_key) const = 0;
 
     virtual ~EcdsaProvider() = default;
   };

--- a/include/libp2p/crypto/ecdsa_provider/ecdsa_provider_impl.hpp
+++ b/include/libp2p/crypto/ecdsa_provider/ecdsa_provider_impl.hpp
@@ -22,9 +22,16 @@ namespace libp2p::crypto::ecdsa {
     outcome::result<Signature> sign(gsl::span<const uint8_t> message,
                                     const PrivateKey &key) const override;
 
+    outcome::result<Signature> signPrehashed(
+        const PrehashedMessage &message, const PrivateKey &key) const override;
+
     outcome::result<bool> verify(gsl::span<const uint8_t> message,
                                  const Signature &signature,
                                  const PublicKey &key) const override;
+
+    outcome::result<bool> verifyPrehashed(
+        const PrehashedMessage &message, const Signature &signature,
+        const PublicKey &public_key) const override;
 
    private:
     /**

--- a/include/libp2p/crypto/ecdsa_types.hpp
+++ b/include/libp2p/crypto/ecdsa_types.hpp
@@ -16,6 +16,7 @@ namespace libp2p::crypto::ecdsa {
   using PrivateKey = std::array<uint8_t, 121>;
   using PublicKey = std::array<uint8_t, 91>;
   using Signature = std::vector<uint8_t>;
+  using PrehashedMessage = std::array<uint8_t, 32>;
 
   /**
    * @struct Key pair


### PR DESCRIPTION
The change allows the dependent projects to pass messages' digests directly to the crypto provider.

Required for the [kagome](github.com/soramitsu/kagome) project.