### PR TITLE
null iterator dereferencing fix

### DIFF
--- a/src/muxer/yamux/yamuxed_connection.cpp
+++ b/src/muxer/yamux/yamuxed_connection.cpp
@@ -467,9 +467,10 @@ namespace libp2p::connection {
         SL_DEBUG(log(), "received ACK on unknown stream id {}",
                  frame.stream_id);
         ok = false;
+      } else {
+        stream_handler = std::move(it->second);
+        erasePendingOutboundStream(it);
       }
-      stream_handler = std::move(it->second);
-      erasePendingOutboundStream(it);
     }
 
     if (!ok) {


### PR DESCRIPTION
Fix for https://github.com/soramitsu/kagome/issues/1204.

The gist is we attempted to unconditionally dereference invalid (namely, end) iterator before reporting connection error. Now we skip this step if stream was not found.