### PR TITLE
Remove TLS dependency on TCP

### DIFF
--- a/include/libp2p/security/tls/tls_errors.hpp
+++ b/include/libp2p/security/tls/tls_errors.hpp
@@ -10,7 +10,6 @@ namespace libp2p::security {
 
   enum class TlsError : int {
     TLS_CTX_INIT_FAILED = 1,
-    TLS_INCOMPATIBLE_TRANSPORT,
     TLS_NO_CERTIFICATE,
     TLS_INCOMPATIBLE_CERTIFICATE_EXTENSION,
     TLS_PEER_VERIFY_FAILED,

--- a/src/security/tls/tls_adaptor.cpp
+++ b/src/security/tls/tls_adaptor.cpp
@@ -10,7 +10,6 @@
 #include <libp2p/security/tls/ssl_context.hpp>
 #include <libp2p/security/tls/tls_details.hpp>
 #include <libp2p/security/tls/tls_errors.hpp>
-#include <libp2p/transport/tcp/tcp_connection.hpp>
 
 #include "tls_connection.hpp"
 
@@ -63,27 +62,12 @@ namespace libp2p::security {
       SL_DEBUG(log(), "securing inbound connection");
     }
 
-    std::optional<std::error_code> ec;
-
-    transport::TcpConnection *tcp_conn = nullptr;
-
-    if (!ec) {
-      tcp_conn = dynamic_cast<transport::TcpConnection *>(conn.get());
-      if (tcp_conn == nullptr) {
-        ec = TlsError::TLS_INCOMPATIBLE_TRANSPORT;
-      } else {
-        auto tls_conn = std::make_shared<TlsConnection>(std::move(conn),
-                                                        ssl_context_,
-                                                        *idmgr_,
-                                                        tcp_conn->socket_,
-                                                        std::move(remote_peer));
-        tls_conn->asyncHandshake(std::move(cb), key_marshaller_);
-      }
-    }
-
-    if (ec) {
-      io_context_->post([cb, ec] { cb(*ec); });
-    }
+    auto tls_conn = std::make_shared<TlsConnection>(std::move(conn),
+                                                    ssl_context_,
+                                                    *idmgr_,
+                                                    io_context_,
+                                                    std::move(remote_peer));
+    tls_conn->asyncHandshake(std::move(cb), key_marshaller_);
   }
 
 }  // namespace libp2p::security

--- a/src/security/tls/tls_connection.cpp
+++ b/src/security/tls/tls_connection.cpp
@@ -20,12 +20,13 @@ namespace libp2p::connection {
       std::shared_ptr<LayerConnection> original_connection,
       std::shared_ptr<boost::asio::ssl::context> ssl_context,
       const peer::IdentityManager &idmgr,
-      tcp_socket_t &tcp_socket,
+      std::shared_ptr<boost::asio::io_context> io_context,
       boost::optional<peer::PeerId> remote_peer)
       : local_peer_(idmgr.getId()),
         original_connection_(std::move(original_connection)),
         ssl_context_(std::move(ssl_context)),
-        socket_(std::ref(tcp_socket), *ssl_context_),
+        socket_{AsAsioReadWrite{std::move(io_context), original_connection_},
+                *ssl_context_},
         remote_peer_(std::move(remote_peer)) {}
 
   void TlsConnection::asyncHandshake(

--- a/src/security/tls/tls_connection.hpp
+++ b/src/security/tls/tls_connection.hpp
@@ -13,6 +13,7 @@
 #include <boost/noncopyable.hpp>
 
 #include <libp2p/common/metrics/instance_count.hpp>
+#include <libp2p/connection/as_asio_read_write.hpp>
 #include <libp2p/connection/secure_connection.hpp>
 #include <libp2p/crypto/key_marshaller.hpp>
 #include <libp2p/peer/identity_manager.hpp>
@@ -25,28 +26,23 @@ namespace libp2p::connection {
                         public std::enable_shared_from_this<TlsConnection>,
                         private boost::noncopyable {
    public:
-    /// lower level socket type is TCP
-    using tcp_socket_t = boost::asio::ip::tcp::socket;
-
-    /// reference as a parameter here allows to upgrade established TCP
-    /// connection
-    using ssl_socket_t = boost::asio::ssl::stream<tcp_socket_t &>;
+    using ssl_socket_t = boost::asio::ssl::stream<AsAsioReadWrite>;
 
     /// Upgraded connection passed to this callback
     using HandshakeCallback = std::function<void(
         outcome::result<std::shared_ptr<connection::SecureConnection>>)>;
 
     /// Ctor.
-    /// \param original_connection TCP connection, established at the moment
+    /// \param original_connection connection, established at the moment
     /// \param ssl_context Wrapper around SSL_CTX
     /// \param idmgr Identity manager, contains this host's keys
-    /// \param tcp_socket Raw socket extracted from raw connection
+    /// \param io_context Asio io context
     /// \param remote_peer Expected peer id of remote peer, has value for
     /// outbound connections
     TlsConnection(std::shared_ptr<LayerConnection> original_connection,
                   std::shared_ptr<boost::asio::ssl::context> ssl_context,
                   const peer::IdentityManager &idmgr,
-                  tcp_socket_t &tcp_socket,
+                  std::shared_ptr<boost::asio::io_context> io_context,
                   boost::optional<peer::PeerId> remote_peer);
 
     /// Performs async handshake and passes its result into callback. This fn is
@@ -113,7 +109,7 @@ namespace libp2p::connection {
     /// Local peer id
     const peer::PeerId local_peer_;
 
-    /// Raw TCP connection
+    /// Raw connection
     std::shared_ptr<LayerConnection> original_connection_;
 
     /// SSL context, shared among connections

--- a/src/security/tls/tls_details.cpp
+++ b/src/security/tls/tls_details.cpp
@@ -522,8 +522,6 @@ OUTCOME_CPP_DEFINE_CATEGORY(libp2p::security, TlsError, e) {
   switch (e) {
     case E::TLS_CTX_INIT_FAILED:
       return "Cannot initialize SSL context";
-    case E::TLS_INCOMPATIBLE_TRANSPORT:
-      return "Incompatible underlying transport";
     case E::TLS_NO_CERTIFICATE:
       return "No peer certificate";
     case E::TLS_INCOMPATIBLE_CERTIFICATE_EXTENSION:


### PR DESCRIPTION
- Remove `dynamic_cast`.
- Can use TLS over any libp2p stream.
- Can use in WASM (browsers don't allow TCP).