### PR TITLE
Hotfix TCP socket leakage

### DIFF
--- a/src/transport/tcp/tcp_transport.cpp
+++ b/src/transport/tcp/tcp_transport.cpp
@@ -41,6 +41,7 @@ namespace libp2p::transport {
           [self, conn, handler{std::move(handler)}, remoteId](auto ec,
                                                               auto &e) mutable {
             if (ec) {
+              conn->close();
               return handler(ec);
             }
 


### PR DESCRIPTION
TCP Connections are stored in shared ptrs and are leaking somewhere, so that when some errors happens while establishing a connection we might end up in a situation when we don't hold any references to the connection in the client code, but the socket for this connection is still open. This can easily lead to open sockets piling up to the point where the process is killed due to running out of file descriptors. This patch closes the socket on error, however the TcpConnection objects will still remain in memory, which will have to be fixed with more based refactoring.