### PR TITLE
remove assert in yamux

### DIFF
--- a/src/muxer/yamux/yamuxed_connection.cpp
+++ b/src/muxer/yamux/yamuxed_connection.cpp
@@ -275,8 +275,6 @@ namespace libp2p::connection {
     for (const auto &[id, handler] : streams_created) {
       auto it = streams_.find(id);
 
-      assert(it != streams_.end());
-
       if (it == streams_.end()) {
         log()->error("fresh_streams_ inconsistency!");
         continue;


### PR DESCRIPTION
There is `if` with same condition after `assert`, so this should not `abort`.