### PR TITLE
Remove unused 'ls' command

### DIFF
--- a/cmake/Hunter/init.cmake
+++ b/cmake/Hunter/init.cmake
@@ -22,7 +22,7 @@ set(
 
 set(
     HUNTER_CACHE_SERVERS
-    "https://github.com/soramitsu/hunter-binary-cache;https://github.com/Warchant/hunter-binary-cache;https://github.com/elucideye/hunter-cache;https://github.com/ingenue/hunter-cache"
+    "https://github.com/soramitsu/hunter-binary-cache"
     CACHE
     STRING
     "Binary cache server"
@@ -31,7 +31,7 @@ set(
 include(${CMAKE_CURRENT_LIST_DIR}/HunterGate.cmake)
 
 HunterGate(
-    URL  "https://github.com/soramitsu/soramitsu-hunter/archive/tags/v0.23.257-soramitsu16.tar.gz"
-    SHA1 "64a1180e8cbeb98d2cfd786bfb725dcdc81d8fa9"
+    URL  https://github.com/soramitsu/soramitsu-hunter/archive/v0.23.257-soramitsu31.tar.gz
+    SHA1 fc89c309edac42e1ec01d74c6cd6f757e72f2492
     LOCAL
 )

--- a/include/libp2p/protocol_muxer/multiselect/common.hpp
+++ b/include/libp2p/protocol_muxer/multiselect/common.hpp
@@ -27,9 +27,6 @@ namespace libp2p::protocol_muxer::multiselect {
   /// Special message N/A
   static constexpr std::string_view kNA("na");
 
-  /// ls request
-  static constexpr std::string_view kLS("ls");
-
   /// Multiselect protocol message, deflated
   struct Message {
     enum Type {

--- a/include/libp2p/protocol_muxer/multiselect/multiselect_instance.hpp
+++ b/include/libp2p/protocol_muxer/multiselect/multiselect_instance.hpp
@@ -41,9 +41,6 @@ namespace libp2p::protocol_muxer::multiselect {
     /// Sends protocol proposal, returns false when all proposals exhausted
     bool sendProposal();
 
-    /// Sends LS reply message
-    void sendLS();
-
     /// Sends NA reply message
     void sendNA();
 
@@ -124,9 +121,6 @@ namespace libp2p::protocol_muxer::multiselect {
 
     /// True if waiting for write callback
     bool is_writing_ = false;
-
-    /// Cache: serialized LS response
-    boost::optional<Packet> ls_response_;
 
     /// Cache: serialized NA response
     boost::optional<Packet> na_response_;

--- a/include/libp2p/protocol_muxer/multiselect/parser.hpp
+++ b/include/libp2p/protocol_muxer/multiselect/parser.hpp
@@ -6,8 +6,8 @@
 #ifndef LIBP2P_MULTISELECT_PARSER_HPP
 #define LIBP2P_MULTISELECT_PARSER_HPP
 
-#include <libp2p/basic/varint_prefix_reader.hpp>
 #include <libp2p/basic/read_buffer.hpp>
+#include <libp2p/basic/varint_prefix_reader.hpp>
 
 #include "common.hpp"
 
@@ -17,11 +17,14 @@ namespace libp2p::protocol_muxer::multiselect::detail {
   /// Logic is similar to that of VarintPrefixReader
   class Parser {
     using VarintPrefixReader = basic::VarintPrefixReader;
+
    public:
     Parser() = default;
 
     /// Number of messages in a packet will rarely exceed 4
     using Messages = boost::container::small_vector<Message, 4>;
+
+    using IndexType = gsl::span<const uint8_t>::index_type;
 
     /// State similar to that of VarintPrefixReader
     enum State {
@@ -39,7 +42,7 @@ namespace libp2p::protocol_muxer::multiselect::detail {
     }
 
     /// Returns protocol messages parsed
-    const Messages& messages() const {
+    const Messages &messages() const {
       return messages_;
     }
 
@@ -81,12 +84,12 @@ namespace libp2p::protocol_muxer::multiselect::detail {
     VarintPrefixReader varint_reader_;
 
     /// Message size expected as per length prefix
-    size_t expected_msg_size_ = 0;
+    IndexType expected_msg_size_ = 0;
 
     /// Recursion depth for nested messages, limited
     size_t recursion_depth_ = 0;
   };
 
-}
+}  // namespace libp2p::protocol_muxer::multiselect::detail
 
 #endif  // LIBP2P_MULTISELECT_PARSER_HPP

--- a/src/protocol_muxer/multiselect/multiselect_instance.cpp
+++ b/src/protocol_muxer/multiselect/multiselect_instance.cpp
@@ -58,7 +58,6 @@ namespace libp2p::protocol_muxer::multiselect {
 
     write_queue_.clear();
     is_writing_ = false;
-    ls_response_.reset();
 
     if (is_initiator_) {
       std::ignore = sendProposal();
@@ -94,18 +93,6 @@ namespace libp2p::protocol_muxer::multiselect {
 
     wait_for_protocol_reply_ = true;
     return true;
-  }
-
-  void MultiselectInstance::sendLS() {
-    if (!ls_response_) {
-      auto msg_res = detail::createMessage(protocols_, true);
-      if (!msg_res) {
-        // will defer error
-        return send(msg_res);
-      }
-      ls_response_ = std::make_shared<MsgBuf>(std::move(msg_res.value()));
-    }
-    send(ls_response_.value());
   }
 
   void MultiselectInstance::sendNA() {
@@ -266,9 +253,6 @@ namespace libp2p::protocol_muxer::multiselect {
           break;
         case Message::kNAMessage:
           result = handleNA();
-          break;
-        case Message::kLSMessage:
-          sendLS();
           break;
         case Message::kWrongProtocolVersion: {
           SL_DEBUG(log(), "Received unsupported protocol version: {}",

--- a/src/protocol_muxer/multiselect/multiselect_instance.cpp
+++ b/src/protocol_muxer/multiselect/multiselect_instance.cpp
@@ -177,7 +177,7 @@ namespace libp2p::protocol_muxer::multiselect {
       return;
     }
 
-    size_t bytes_needed = parser_.bytesNeeded();
+    auto bytes_needed = parser_.bytesNeeded();
 
     assert(bytes_needed > 0);
 
@@ -188,7 +188,7 @@ namespace libp2p::protocol_muxer::multiselect {
     }
 
     gsl::span<uint8_t> span(*read_buffer_);
-    span = span.first(bytes_needed);
+    span = span.first(static_cast<Parser::IndexType>(bytes_needed));
 
     connection_->read(span, bytes_needed,
                       [wptr = weak_from_this(), round = current_round_,
@@ -205,14 +205,14 @@ namespace libp2p::protocol_muxer::multiselect {
       return close(res.error());
     }
 
-    size_t bytes_read = res.value();
+    auto bytes_read = res.value();
     if (bytes_read > read_buffer_->size()) {
       log()->error("onDataRead(): invalid state");
       return close(ProtocolMuxer::Error::INTERNAL_ERROR);
     }
 
     gsl::span<const uint8_t> span(*read_buffer_);
-    span = span.first(bytes_read);
+    span = span.first(static_cast<Parser::IndexType>(bytes_read));
 
     SL_TRACE(log(), "received {}", common::dumpBin(span));
 

--- a/src/protocol_muxer/multiselect/parser.cpp
+++ b/src/protocol_muxer/multiselect/parser.cpp
@@ -47,7 +47,12 @@ namespace libp2p::protocol_muxer::multiselect::detail {
           state_ = kOverflow;
           break;
         }
-        expected_msg_size_ = varint_reader_.value();
+        if (varint_reader_.value()
+            > std::numeric_limits<decltype(expected_msg_size_)>::max()) {
+          state_ = kError;
+          break;
+        }
+        expected_msg_size_ = static_cast<IndexType>(varint_reader_.value());
         if (expected_msg_size_ == 0) {
           // zero varint received, not acceptable, but not fatal
           reset();

--- a/src/protocol_muxer/multiselect/parser.cpp
+++ b/src/protocol_muxer/multiselect/parser.cpp
@@ -74,12 +74,12 @@ namespace libp2p::protocol_muxer::multiselect::detail {
   }
 
   void Parser::readFinished(gsl::span<const uint8_t> msg) {
-    assert(expected_msg_size_ == static_cast<size_t>(msg.size()));
+    assert(expected_msg_size_ == msg.size());
     assert(expected_msg_size_ != 0);
 
     auto span2sv = [](gsl::span<const uint8_t> span) -> std::string_view {
       if (span.empty()) {
-        return std::string_view();
+        return {};
       }
       return std::string_view((const char *)(span.data()),  // NOLINT
                               static_cast<size_t>(span.size()));

--- a/src/protocol_muxer/multiselect/parser.cpp
+++ b/src/protocol_muxer/multiselect/parser.cpp
@@ -173,12 +173,10 @@ namespace libp2p::protocol_muxer::multiselect::detail {
       }
       if (msg.content == kNA) {
         msg.type = Message::kNAMessage;
-      } else if (msg.content == kLS) {
-        msg.type = Message::kLSMessage;
       }
     }
 
     state_ = kReady;
   }
 
-}  // namespace libp2p::protocol_muxer::mutiselect::detail
+}  // namespace libp2p::protocol_muxer::multiselect::detail

--- a/test/libp2p/protocol_muxer/multiselect_test.cpp
+++ b/test/libp2p/protocol_muxer/multiselect_test.cpp
@@ -16,8 +16,8 @@
  * @then bad_alloc is thrown
  */
 TEST(Multiselect, TmpBufThrows) {
-  using libp2p::protocol_muxer::multiselect::detail::TmpMsgBuf;
   using libp2p::protocol_muxer::multiselect::kMaxMessageSize;
+  using libp2p::protocol_muxer::multiselect::detail::TmpMsgBuf;
   TmpMsgBuf buf;
   buf.resize(kMaxMessageSize / 2);
   EXPECT_THROW(buf.resize(buf.capacity() + 1), std::bad_alloc);
@@ -27,14 +27,13 @@ TEST(Multiselect, SingleValidMessages) {
   using namespace libp2p::protocol_muxer::multiselect;
 
   std::vector<Message> messages({
-                                    {Message::kRightProtocolVersion, "/multistream/1.0.0"},
-                                    {Message::kRightProtocolVersion, "/multistream/1.0.1"},
-                                    {Message::kRightProtocolVersion, "/multistream-select/0.4.0"},
-                                    {Message::kWrongProtocolVersion, "/multistream/2.0.0"},
-                                    {Message::kProtocolName, "/echo/1.0.0"},
-                                    {Message::kNAMessage, "na"},
-                                    {Message::kLSMessage, "ls"},
-                                });
+      {Message::kRightProtocolVersion, "/multistream/1.0.0"},
+      {Message::kRightProtocolVersion, "/multistream/1.0.1"},
+      {Message::kRightProtocolVersion, "/multistream-select/0.4.0"},
+      {Message::kWrongProtocolVersion, "/multistream/2.0.0"},
+      {Message::kProtocolName, "/echo/1.0.0"},
+      {Message::kNAMessage, "na"},
+  });
 
   detail::Parser reader;
   for (const auto &m : messages) {
@@ -55,14 +54,13 @@ TEST(Multiselect, SingleValidMessagesPartialRead) {
   using namespace libp2p::protocol_muxer::multiselect;
 
   std::vector<Message> messages({
-                                    {Message::kRightProtocolVersion, "/multistream/1.0.0"},
-                                    {Message::kRightProtocolVersion, "/multistream/1.0.1"},
-                                    {Message::kRightProtocolVersion, "/multistream-select/0.4.0"},
-                                    {Message::kWrongProtocolVersion, "/multistream/2.0.0"},
-                                    {Message::kProtocolName, "/echo/1.0.0"},
-                                    {Message::kNAMessage, "na"},
-                                    {Message::kLSMessage, "ls"},
-                                });
+      {Message::kRightProtocolVersion, "/multistream/1.0.0"},
+      {Message::kRightProtocolVersion, "/multistream/1.0.1"},
+      {Message::kRightProtocolVersion, "/multistream-select/0.4.0"},
+      {Message::kWrongProtocolVersion, "/multistream/2.0.0"},
+      {Message::kProtocolName, "/echo/1.0.0"},
+      {Message::kNAMessage, "na"},
+  });
 
   using Span = gsl::span<const uint8_t>;
 


### PR DESCRIPTION
Unused 'ls' command has removed in following.

Implemented following https://github.com/multiformats/go-multistream/pull/76.

Resolves issue https://github.com/soramitsu/kagome/issues/1352