### PR TITLE
fix: use the correct x509 version

### DIFF
--- a/src/security/tls/tls_details.cpp
+++ b/src/security/tls/tls_details.cpp
@@ -69,9 +69,10 @@ namespace libp2p::security::tls_details {
                       subject_name.size());
 
     log()->log(status ? log::Level::TRACE : log::Level::INFO,
-              "in certificate verify callback, subject={}, error={} ({}), "
-              "depth={}, status={}",
-              subject_name.data(), x509ErrorToStr(error), error, depth, status);
+               "in certificate verify callback, subject={}, error={} ({}), "
+               "depth={}, status={}",
+               subject_name.data(), x509ErrorToStr(error), error, depth,
+               status);
     return status;
   }
 
@@ -143,6 +144,7 @@ namespace libp2p::security::tls_details {
       memcpy(pk_data.data(), host_private_key.data.data(), 32);
 
       return crypto::ed25519::Ed25519ProviderImpl{}
+          // NOLINTNEXTLINE(cppcoreguidelines-narrowing-conversions)
           .sign(gsl::span<const uint8_t>(buf, msg_len), pk_data)
           .value();
     }
@@ -152,6 +154,7 @@ namespace libp2p::security::tls_details {
                       const crypto::ecdsa::PublicKey &cert_pub_key) {
       EVP_PKEY *pub = nullptr;
       const auto *data = cert_pub_key.data();
+      // NOLINTNEXTLINE(cppcoreguidelines-narrowing-conversions)
       d2i_PUBKEY(&pub, &data, cert_pub_key.size());
       if (pub == nullptr) {
         throw std::runtime_error("cannot deserialize certificate public key");
@@ -207,6 +210,7 @@ namespace libp2p::security::tls_details {
         X509 *cert, const std::array<uint8_t, kExtensionDataSize> &ext_data) {
       ASN1_OCTET_STRING *os = ASN1_OCTET_STRING_new();
       CLEANUP_PTR(os, ASN1_OCTET_STRING_free);
+      // NOLINTNEXTLINE(cppcoreguidelines-narrowing-conversions)
       ASN1_OCTET_STRING_set(os, ext_data.data(), ext_data.size());
 
       ASN1_OBJECT *obj = OBJ_txt2obj(extension_oid.data(), 1);
@@ -224,6 +228,7 @@ namespace libp2p::security::tls_details {
                          const crypto::ecdsa::PrivateKey &priv_key) {
       EC_KEY *ec_key = nullptr;
       const uint8_t *data = priv_key.data();
+      // NOLINTNEXTLINE(cppcoreguidelines-narrowing-conversions)
       d2i_ECPrivateKey(&ec_key, &data, priv_key.size());
       if (ec_key == nullptr) {
         throw std::runtime_error("cannot deserialize ECDSA private key");
@@ -362,7 +367,7 @@ namespace libp2p::security::tls_details {
 
       if (!verify_res) {
         log()->info("peer {} verification failed, {}", peer_id.toBase58(),
-                   verify_res.error().message());
+                    verify_res.error().message());
         return TlsError::TLS_PEER_VERIFY_FAILED;
       }
 

--- a/src/security/tls/tls_details.cpp
+++ b/src/security/tls/tls_details.cpp
@@ -259,7 +259,7 @@ namespace libp2p::security::tls_details {
     // 3. Create certificate
     X509 *cert = X509_new();
     CLEANUP_PTR(cert, X509_free);
-    X509_set_version(cert, 3);
+    X509_set_version(cert, 2);
     assignPubkey(cert, cert_keys.public_key);
     assignSerial(cert);
     assignIssuer(cert);


### PR DESCRIPTION
Since we want to use version 3, we actually need to pass 2 here. I know it's confusing. Without this you will fail to interop with go-libp2p nodes since they have no idea how to parse an unknown version of x509.

Sources:
- https://github.com/openssl/openssl/blob/master/include/openssl/x509.h.in#L646
> Note: the values of these constants are defined by standards (X.509 et al) to be one less than the certificate version. So X509_VERSION_3 has value 2 and X509_VERSION_1 has value 0.
https://www.openssl.org/docs/man3.0/man3/X509_set_version.html
- Sample cert on wiki: https://en.wikipedia.org/wiki/X.509#End-entity_certificate

Note it might be better to use the defined constant `X509_VERSION_3`, but I haven't compiled the project so I knew s/3/2 was a safe change.