### PR TITLE
fix: prevent segmentation fault when receiving empty message (#199)

### DIFF
--- a/include/libp2p/basic/protobuf_message_read_writer.hpp
+++ b/include/libp2p/basic/protobuf_message_read_writer.hpp
@@ -46,6 +46,10 @@ namespace libp2p::basic {
             }
 
             auto &&buf = res.value();
+            if (!buf) {
+              return cb(ProtoMsgType{});
+            }
+
             ProtoMsgType msg;
             msg.ParseFromArray(buf->data(), buf->size());
             if (bytes) {


### PR DESCRIPTION
Fix to prevent segmentation fault when receiving empty protobuf message by checking if returned shared pointer contains null and if so, just calling the callback.