### PR TITLE
Refactor read write some

### DIFF
--- a/cmake/Hunter/HunterGate.cmake
+++ b/cmake/Hunter/HunterGate.cmake
@@ -25,7 +25,7 @@
 # This is a gate file to Hunter package manager.
 # Include this file using `include` command and add package you need, example:
 #
-#     cmake_minimum_required(VERSION 3.2)
+#     cmake_minimum_required(VERSION 3.5)
 #
 #     include("cmake/HunterGate.cmake")
 #     HunterGate(
@@ -257,7 +257,7 @@ function(hunter_gate_download dir)
   file(
       WRITE
       "${cmakelists}"
-      "cmake_minimum_required(VERSION 3.2)\n"
+      "cmake_minimum_required(VERSION 3.5)\n"
       "project(HunterDownload LANGUAGES NONE)\n"
       "include(ExternalProject)\n"
       "ExternalProject_Add(\n"

--- a/include/libp2p/basic/read.hpp
+++ b/include/libp2p/basic/read.hpp
@@ -14,46 +14,31 @@ namespace libp2p {
   inline void read(const std::shared_ptr<basic::Reader> &reader,
                    BytesOut out,
                    std::function<void(outcome::result<void>)> cb) {
-    auto post_cb = [](decltype(reader) reader,
-                      decltype(cb) &&cb,
-                      outcome::result<size_t> r) {
-      reader->deferReadCallback(r,
-                                [cb{std::move(cb)}](outcome::result<size_t> r) {
-                                  if (r.has_error()) {
-                                    cb(r.error());
-                                  } else {
-                                    cb(outcome::success());
-                                  }
-                                });
-    };
-    if (out.empty()) {
-      return post_cb(reader, std::move(cb), outcome::success());
-    }
     // read some bytes
     reader->readSome(
         out,
         out.size(),
-        [weak{std::weak_ptr{reader}}, out, cb{std::move(cb)}, post_cb](
+        [weak{std::weak_ptr{reader}}, out, cb{std::move(cb)}](
             outcome::result<size_t> n_res) mutable {
-          auto reader = weak.lock();
-          if (not reader) {
-            return;
-          }
           if (n_res.has_error()) {
-            return post_cb(reader, std::move(cb), n_res.error());
+            return cb(n_res.error());
           }
           auto n = n_res.value();
+          if (n == out.size()) {
+            // successfully read last bytes
+            return cb(outcome::success());
+          }
           if (n == 0) {
             throw std::logic_error{"libp2p::read zero bytes read"};
           }
           if (n > out.size()) {
             throw std::logic_error{"libp2p::read too much bytes read"};
           }
-          if (n == out.size()) {
-            // successfully read last bytes
-            return post_cb(reader, std::move(cb), outcome::success());
-          }
           // read remaining bytes
+          auto reader = weak.lock();
+          if (not reader) {
+            return cb(std::errc::operation_canceled);
+          }
           read(reader, out.subspan(n), std::move(cb));
         });
   }

--- a/include/libp2p/basic/write.hpp
+++ b/include/libp2p/basic/write.hpp
@@ -1,0 +1,45 @@
+/**
+ * Copyright Quadrivium LLC
+ * All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <libp2p/basic/writer.hpp>
+#include <memory>
+
+namespace libp2p {
+  /// Write exactly `in.size()` bytes
+  inline void write(const std::shared_ptr<basic::Writer> &writer,
+                    BytesIn in,
+                    std::function<void(outcome::result<void>)> cb) {
+    // write some bytes
+    writer->writeSome(
+        in,
+        in.size(),
+        [weak{std::weak_ptr{writer}}, in, cb{std::move(cb)}](
+            outcome::result<size_t> n_res) mutable {
+          if (n_res.has_error()) {
+            return cb(n_res.error());
+          }
+          auto n = n_res.value();
+          if (n == in.size()) {
+            // successfully wrote last bytes
+            return cb(outcome::success());
+          }
+          if (n == 0) {
+            throw std::logic_error{"libp2p::write zero bytes written"};
+          }
+          if (n > in.size()) {
+            throw std::logic_error{"libp2p::write too much bytes written"};
+          }
+          // write remaining bytes
+          auto writer = weak.lock();
+          if (not writer) {
+            return cb(std::errc::operation_canceled);
+          }
+          write(writer, in.subspan(n), std::move(cb));
+        });
+  }
+}  // namespace libp2p

--- a/include/libp2p/basic/write_queue.hpp
+++ b/include/libp2p/basic/write_queue.hpp
@@ -29,10 +29,10 @@ namespace libp2p::basic {
     size_t unsentBytes() const;
 
     /// Enqueues data
-    void enqueue(DataRef data, bool some, basic::Writer::WriteCallbackFunc cb);
+    void enqueue(DataRef data, basic::Writer::WriteCallbackFunc cb);
 
     /// Returns new window size
-    size_t dequeue(size_t window_size, DataRef &out, bool &some);
+    size_t dequeue(size_t window_size, DataRef &out);
 
     struct AckResult {
       // callback to be called to ack data was sent
@@ -45,7 +45,7 @@ namespace libp2p::basic {
       bool data_consistent = true;
     };
 
-    /// Calls write callback if full message was sent (or some),
+    /// Calls write callback if full message was sent,
     /// returns callback to ack + true if ok or false on inconsistency
     [[nodiscard]] AckResult ackDataSent(size_t size);
 
@@ -69,9 +69,6 @@ namespace libp2p::basic {
 
       // remaining bytes to dequeue
       size_t unsent;
-
-      // allows to send at least 1 byte to complete operation
-      bool some;
 
       // callback
       basic::Writer::WriteCallbackFunc cb;

--- a/include/libp2p/basic/write_return_size.hpp
+++ b/include/libp2p/basic/write_return_size.hpp
@@ -1,0 +1,25 @@
+/**
+ * Copyright Quadrivium LLC
+ * All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <libp2p/basic/write.hpp>
+
+namespace libp2p {
+  /// Write exactly `in.size()` bytes
+  inline void writeReturnSize(const std::shared_ptr<basic::Writer> &writer,
+                              BytesIn in,
+                              basic::Writer::WriteCallbackFunc cb) {
+    write(
+        writer, in, [n{in.size()}, cb{std::move(cb)}](outcome::result<void> r) {
+          if (r.has_error()) {
+            cb(r.error());
+          } else {
+            cb(n);
+          }
+        });
+  }
+}  // namespace libp2p

--- a/include/libp2p/connection/loopback_stream.hpp
+++ b/include/libp2p/connection/loopback_stream.hpp
@@ -55,8 +55,6 @@ namespace libp2p::connection {
     void deferWriteCallback(std::error_code ec, WriteCallbackFunc cb) override;
 
    private:
-    void read(BytesOut out, size_t bytes, ReadCallbackFunc cb, bool some);
-
     libp2p::peer::PeerInfo own_peer_info_;
     std::shared_ptr<boost::asio::io_context> io_context_;
 

--- a/include/libp2p/muxer/mplex/mplex_stream.hpp
+++ b/include/libp2p/muxer/mplex/mplex_stream.hpp
@@ -88,12 +88,10 @@ namespace libp2p::connection {
       BytesOut out;
       size_t bytes;
       ReadCallbackFunc cb;
-      bool some;
     };
 
     void readDone(outcome::result<size_t> res);
     bool readTry();
-    void read(BytesOut out, size_t bytes, ReadCallbackFunc cb, bool some);
 
     std::weak_ptr<MplexedConnection> connection_;
     StreamId stream_id_;

--- a/include/libp2p/muxer/yamux/yamux_stream.hpp
+++ b/include/libp2p/muxer/yamux/yamux_stream.hpp
@@ -21,9 +21,7 @@ namespace libp2p::connection {
     virtual ~YamuxStreamFeedback() = default;
 
     /// Stream transfers data to connection
-    virtual void writeStreamData(uint32_t stream_id,
-                                 BytesIn data,
-                                 bool some) = 0;
+    virtual void writeStreamData(uint32_t stream_id, BytesIn data) = 0;
 
     /// Stream acknowledges received bytes
     virtual void ackReceivedBytes(uint32_t stream_id, uint32_t bytes) = 0;
@@ -118,7 +116,7 @@ namespace libp2p::connection {
     void doClose(std::error_code ec, bool notify_read_side);
 
     /// Called by read*() functions
-    void doRead(BytesOut out, size_t bytes, ReadCallbackFunc cb, bool some);
+    void doRead(BytesOut out, size_t bytes, ReadCallbackFunc cb);
 
     /// Completes the read operation if any, clears read state
     [[nodiscard]] std::pair<ReadCallbackFunc, outcome::result<size_t>>
@@ -128,7 +126,7 @@ namespace libp2p::connection {
     void doWrite();
 
     /// Called by write*() functions
-    void doWrite(BytesIn in, size_t bytes, WriteCallbackFunc cb, bool some);
+    void doWrite(BytesIn in, size_t bytes, WriteCallbackFunc cb);
 
     /// Clears close callback state
     [[nodiscard]] std::pair<VoidResultHandlerFunc, outcome::result<void>>
@@ -175,9 +173,6 @@ namespace libp2p::connection {
 
     /// True if read operation is active
     bool is_reading_ = false;
-
-    /// Read operation is readSome()
-    bool reading_some_ = false;
 
     /// Read callback, it is non-zero during async data receive
     ReadCallbackFunc read_cb_;

--- a/include/libp2p/muxer/yamux/yamuxed_connection.hpp
+++ b/include/libp2p/muxer/yamux/yamuxed_connection.hpp
@@ -91,13 +91,12 @@ namespace libp2p::connection {
 
       Buffer packet;
       StreamId stream_id;
-      bool some;
     };
 
     // YamuxStreamFeedback interface overrides
 
     /// Stream transfers data to connection
-    void writeStreamData(uint32_t stream_id, BytesIn data, bool some) override;
+    void writeStreamData(uint32_t stream_id, BytesIn data) override;
 
     /// Stream acknowledges received bytes
     void ackReceivedBytes(uint32_t stream_id, uint32_t bytes) override;
@@ -155,15 +154,13 @@ namespace libp2p::connection {
 
     /// Writes data to underlying connection or (if is_writing_) enqueues them
     /// If stream_id != 0, stream will be acknowledged about data written
-    void enqueue(Buffer packet, StreamId stream_id = 0, bool some = false);
+    void enqueue(Buffer packet, StreamId stream_id = 0);
 
     /// Performs write into connection
     void doWrite(WriteQueueItem packet);
 
     /// Write callback
-    void onDataWritten(outcome::result<size_t> res,
-                       StreamId stream_id,
-                       bool some);
+    void onDataWritten(outcome::result<size_t> res, StreamId stream_id);
 
     /// Creates new yamux stream
     std::shared_ptr<Stream> createStream(StreamId stream_id);

--- a/include/libp2p/security/noise/noise_connection.hpp
+++ b/include/libp2p/security/noise/noise_connection.hpp
@@ -72,11 +72,6 @@ namespace libp2p::connection {
     outcome::result<crypto::PublicKey> remotePublicKey() const override;
 
    private:
-    void read(BytesOut out,
-              size_t bytes,
-              OperationContext ctx,
-              ReadCallbackFunc cb);
-
     void readSome(BytesOut out,
                   size_t bytes,
                   OperationContext ctx,

--- a/src/layer/websocket/ssl_connection.cpp
+++ b/src/layer/websocket/ssl_connection.cpp
@@ -7,6 +7,7 @@
 #include <libp2p/layer/websocket/ssl_connection.hpp>
 
 #include <libp2p/basic/read_return_size.hpp>
+#include <libp2p/basic/write_return_size.hpp>
 #include <libp2p/common/ambigous_size.hpp>
 #include <libp2p/common/asio_buffer.hpp>
 #include <libp2p/common/asio_cb.hpp>
@@ -61,7 +62,7 @@ namespace libp2p::connection {
                             size_t bytes,
                             libp2p::basic::Writer::WriteCallbackFunc cb) {
     ambigousSize(in, bytes);
-    boost::asio::async_write(ssl_, asioBuffer(in), toAsioCbSize(std::move(cb)));
+    writeReturnSize(shared_from_this(), in, std::move(cb));
   }
 
   void SslConnection::writeSome(BytesIn in,

--- a/src/layer/websocket/ws_connection.cpp
+++ b/src/layer/websocket/ws_connection.cpp
@@ -7,6 +7,7 @@
 #include <libp2p/layer/websocket/ws_connection.hpp>
 
 #include <libp2p/basic/read_return_size.hpp>
+#include <libp2p/basic/write_return_size.hpp>
 #include <libp2p/common/ambigous_size.hpp>
 #include <libp2p/common/asio_buffer.hpp>
 #include <libp2p/common/asio_cb.hpp>
@@ -160,7 +161,7 @@ namespace libp2p::connection {
                            libp2p::basic::Writer::WriteCallbackFunc cb) {
     ambigousSize(in, bytes);
     SL_TRACE(log_, "write {} bytes", bytes);
-    ws_.async_write(asioBuffer(in), toAsioCbSize(std::move(cb)));
+    writeReturnSize(shared_from_this(), in, std::move(cb));
   }
 
   void WsConnection::writeSome(BytesIn in,    //

--- a/src/security/noise/noise_connection.cpp
+++ b/src/security/noise/noise_connection.cpp
@@ -6,6 +6,9 @@
 
 #include <libp2p/security/noise/noise_connection.hpp>
 
+#include <libp2p/basic/read_return_size.hpp>
+#include <libp2p/basic/write_return_size.hpp>
+#include <libp2p/common/ambigous_size.hpp>
 #include <libp2p/crypto/x25519_provider/x25519_provider_impl.hpp>
 #include <libp2p/security/noise/crypto/interfaces.hpp>
 
@@ -63,29 +66,8 @@ namespace libp2p::connection {
   void NoiseConnection::read(BytesOut out,
                              size_t bytes,
                              libp2p::basic::Reader::ReadCallbackFunc cb) {
-    OperationContext context{.bytes_served = 0,
-                             .total_bytes = bytes,
-                             .write_buffer = write_buffers_.end()};
-    read(out, bytes, context, std::move(cb));
-  }
-
-  void NoiseConnection::read(BytesOut out,
-                             size_t bytes,
-                             OperationContext ctx,
-                             ReadCallbackFunc cb) {
-    BOOST_ASSERT(out.size() >= bytes);
-    if (0 == bytes) {
-      BOOST_ASSERT(ctx.bytes_served == ctx.total_bytes);
-      return cb(ctx.bytes_served);
-    }
-    readSome(out,
-             bytes,
-             [self{shared_from_this()}, out, bytes, cb{std::move(cb)}, ctx](
-                 auto _n) mutable {
-               OUTCOME_CB(n, _n);
-               ctx.bytes_served += n;
-               self->read(out.subspan(n), bytes - n, ctx, std::move(cb));
-             });
+    ambigousSize(out, bytes);
+    readReturnSize(shared_from_this(), out, std::move(cb));
   }
 
   void NoiseConnection::readSome(BytesOut out,
@@ -122,10 +104,8 @@ namespace libp2p::connection {
   void NoiseConnection::write(BytesIn in,
                               size_t bytes,
                               libp2p::basic::Writer::WriteCallbackFunc cb) {
-    OperationContext context{.bytes_served = 0,
-                             .total_bytes = bytes,
-                             .write_buffer = write_buffers_.end()};
-    write(in, bytes, context, std::move(cb));
+    ambigousSize(in, bytes);
+    writeReturnSize(shared_from_this(), in, std::move(cb));
   }
 
   void NoiseConnection::write(BytesIn in,
@@ -162,7 +142,12 @@ namespace libp2p::connection {
   void NoiseConnection::writeSome(BytesIn in,
                                   size_t bytes,
                                   libp2p::basic::Writer::WriteCallbackFunc cb) {
-    write(in, bytes, std::move(cb));
+    OperationContext context{
+        .bytes_served = 0,
+        .total_bytes = bytes,
+        .write_buffer = write_buffers_.end(),
+    };
+    write(in, bytes, context, std::move(cb));
   }
 
   void NoiseConnection::deferReadCallback(outcome::result<size_t> res,

--- a/src/security/tls/tls_connection.cpp
+++ b/src/security/tls/tls_connection.cpp
@@ -8,6 +8,7 @@
 #include "tls_details.hpp"
 
 #include <libp2p/basic/read_return_size.hpp>
+#include <libp2p/basic/write_return_size.hpp>
 #include <libp2p/common/ambigous_size.hpp>
 
 namespace libp2p::connection {
@@ -171,9 +172,9 @@ namespace libp2p::connection {
   void TlsConnection::write(BytesIn in,
                             size_t bytes,
                             Writer::WriteCallbackFunc cb) {
+    ambigousSize(in, bytes);
     SL_TRACE(log(), "writing {} bytes", bytes);
-    boost::asio::async_write(
-        socket_, makeBuffer(in, bytes), closeOnError(*this, std::move(cb)));
+    writeReturnSize(shared_from_this(), in, std::move(cb));
   }
 
   void TlsConnection::writeSome(BytesIn in,

--- a/src/transport/tcp/tcp_connection.cpp
+++ b/src/transport/tcp/tcp_connection.cpp
@@ -7,6 +7,7 @@
 #include <libp2p/transport/tcp/tcp_connection.hpp>
 
 #include <libp2p/basic/read_return_size.hpp>
+#include <libp2p/basic/write_return_size.hpp>
 #include <libp2p/common/ambigous_size.hpp>
 #include <libp2p/transport/tcp/tcp_util.hpp>
 
@@ -243,10 +244,9 @@ namespace libp2p::transport {
   void TcpConnection::write(BytesIn in,
                             size_t bytes,
                             TcpConnection::WriteCallbackFunc cb) {
+    ambigousSize(in, bytes);
     TRACE("{} write {}", debug_str_, bytes);
-    boost::asio::async_write(socket_,
-                             detail::makeBuffer(in, bytes),
-                             closeOnError(*this, std::move(cb)));
+    writeReturnSize(shared_from_this(), in, std::move(cb));
   }
 
   void TcpConnection::writeSome(BytesIn in,


### PR DESCRIPTION
- Deduplicate `Reader::read`/`Writer::write` implementations with free `read`/`write` which use `Reader::readSome`/`Writer::writeSome`
- `read`/`write` success means exactly `size` bytes were read/write.
  So callbacks don't need `outcome<size>`.
  This prevents redundant size checks in callbacks.
  Callbacks will capture buffer size if they need it.
- Fix yamux `writeSome` (can't `writeSome`/split already encoded frame with length in header)
