### PR TITLE
tcp listener ws wss address

### DIFF
--- a/include/libp2p/transport/tcp/tcp_util.hpp
+++ b/include/libp2p/transport/tcp/tcp_util.hpp
@@ -17,7 +17,10 @@
 
 namespace libp2p::transport::detail {
   template <typename T>
-  inline outcome::result<multi::Multiaddress> makeAddress(T &&endpoint) {
+  inline outcome::result<multi::Multiaddress> makeAddress(
+      T &&endpoint,
+      const std::vector<std::pair<multi::Protocol, std::string>> *layers =
+          nullptr) {
     try {
       auto address = endpoint.address();
       auto port = endpoint.port();
@@ -31,6 +34,16 @@ namespace libp2p::transport::detail {
       }
 
       s << "/tcp/" << port;
+
+      if (layers != nullptr and not layers->empty()) {
+        auto &protocol = layers->at(0).first.code;
+        using P = multi::Protocol::Code;
+        if (protocol == P::WS) {
+          s << "/ws";
+        } else if (protocol == P::WSS) {
+          s << "/wss";
+        }
+      }
 
       return multi::Multiaddress::create(s.str());
     } catch (const boost::system::system_error &e) {

--- a/src/transport/tcp/tcp_listener.cpp
+++ b/src/transport/tcp/tcp_listener.cpp
@@ -63,7 +63,7 @@ namespace libp2p::transport {
     if (ec) {
       return ec;
     }
-    return detail::makeAddress(endpoint);
+    return detail::makeAddress(endpoint, &layers_);
   }
 
   bool TcpListener::isClosed() const {

--- a/test/libp2p/protocol_muxer/multiselect_test.cpp
+++ b/test/libp2p/protocol_muxer/multiselect_test.cpp
@@ -20,7 +20,7 @@ TEST(Multiselect, TmpBufThrows) {
   using libp2p::protocol_muxer::multiselect::detail::TmpMsgBuf;
   TmpMsgBuf buf;
   buf.resize(kMaxMessageSize / 2);
-  EXPECT_THROW(buf.resize(buf.capacity() + 1), std::bad_alloc);
+  EXPECT_THROW(buf.resize(buf.capacity() + 1), boost::container::bad_alloc_t);
 }
 
 TEST(Multiselect, SingleValidMessages) {


### PR DESCRIPTION
Fix publishing both "/tcp" and "/tcp/ws" for same port.