### PR TITLE
write free function

### DIFF
--- a/include/libp2p/basic/writer.hpp
+++ b/include/libp2p/basic/writer.hpp
@@ -20,21 +20,6 @@ namespace libp2p::basic {
     virtual ~Writer() = default;
 
     /**
-     * @brief Write exactly {@code} in.size() {@nocode} bytes.
-     * Won't call \param cb before all are successfully written.
-     * Returns immediately.
-     * @param in data to write.
-     * @param bytes number of bytes to write
-     * @param cb callback with result of operation
-     *
-     * @note caller should maintain validity of an input buffer until callback
-     * is executed. It is usually done with either wrapping buffer as shared
-     * pointer, or having buffer as part of some class/struct, and using
-     * enable_shared_from_this()
-     */
-    virtual void write(BytesIn in, size_t bytes, WriteCallbackFunc cb) = 0;
-
-    /**
      * @brief Write up to {@code} in.size() {@nocode} bytes.
      * Calls \param cb after only some bytes has been successfully written,
      * so doesn't guarantee that all will be. Returns immediately.

--- a/include/libp2p/connection/loopback_stream.hpp
+++ b/include/libp2p/connection/loopback_stream.hpp
@@ -45,8 +45,6 @@ namespace libp2p::connection {
 
     void readSome(BytesOut out, size_t bytes, ReadCallbackFunc cb) override;
 
-    void write(BytesIn in, size_t bytes, WriteCallbackFunc cb) override;
-
     void writeSome(BytesIn in, size_t bytes, WriteCallbackFunc cb) override;
 
     void deferReadCallback(outcome::result<size_t> res,

--- a/include/libp2p/layer/websocket/ssl_connection.hpp
+++ b/include/libp2p/layer/websocket/ssl_connection.hpp
@@ -37,7 +37,6 @@ namespace libp2p::connection {
     void deferReadCallback(outcome::result<size_t> res,
                            ReadCallbackFunc cb) override;
 
-    void write(BytesIn in, size_t bytes, WriteCallbackFunc cb) override;
     void writeSome(BytesIn in, size_t bytes, WriteCallbackFunc cb) override;
     void deferWriteCallback(std::error_code ec, WriteCallbackFunc cb) override;
 

--- a/include/libp2p/layer/websocket/ws_connection.hpp
+++ b/include/libp2p/layer/websocket/ws_connection.hpp
@@ -75,8 +75,6 @@ namespace libp2p::connection {
     void deferReadCallback(outcome::result<size_t> res,
                            ReadCallbackFunc cb) override;
 
-    void write(BytesIn in, size_t bytes, WriteCallbackFunc cb) override;
-
     void writeSome(BytesIn in, size_t bytes, WriteCallbackFunc cb) override;
 
     void deferWriteCallback(std::error_code ec, WriteCallbackFunc cb) override;

--- a/include/libp2p/muxer/mplex/mplex_stream.hpp
+++ b/include/libp2p/muxer/mplex/mplex_stream.hpp
@@ -57,8 +57,6 @@ namespace libp2p::connection {
     void deferReadCallback(outcome::result<size_t> res,
                            ReadCallbackFunc cb) override;
 
-    void write(BytesIn in, size_t bytes, WriteCallbackFunc cb) override;
-
     void writeSome(BytesIn in, size_t bytes, WriteCallbackFunc cb) override;
 
     void deferWriteCallback(std::error_code ec, WriteCallbackFunc cb) override;

--- a/include/libp2p/muxer/mplex/mplexed_connection.hpp
+++ b/include/libp2p/muxer/mplex/mplexed_connection.hpp
@@ -66,7 +66,6 @@ namespace libp2p::connection {
     /// use stream over this connection instead
     void read(BytesOut out, size_t bytes, ReadCallbackFunc cb) override;
     void readSome(BytesOut out, size_t bytes, ReadCallbackFunc cb) override;
-    void write(BytesIn in, size_t bytes, WriteCallbackFunc cb) override;
     void writeSome(BytesIn in, size_t bytes, WriteCallbackFunc cb) override;
 
     void deferReadCallback(outcome::result<size_t> res,

--- a/include/libp2p/muxer/yamux/yamux_stream.hpp
+++ b/include/libp2p/muxer/yamux/yamux_stream.hpp
@@ -59,8 +59,6 @@ namespace libp2p::connection {
     void deferReadCallback(outcome::result<size_t> res,
                            ReadCallbackFunc cb) override;
 
-    void write(BytesIn in, size_t bytes, WriteCallbackFunc cb) override;
-
     void writeSome(BytesIn in, size_t bytes, WriteCallbackFunc cb) override;
 
     void deferWriteCallback(std::error_code ec, WriteCallbackFunc cb) override;

--- a/include/libp2p/muxer/yamux/yamuxed_connection.hpp
+++ b/include/libp2p/muxer/yamux/yamuxed_connection.hpp
@@ -113,7 +113,6 @@ namespace libp2p::connection {
     /// use stream over this connection instead
     void read(BytesOut out, size_t bytes, ReadCallbackFunc cb) override;
     void readSome(BytesOut out, size_t bytes, ReadCallbackFunc cb) override;
-    void write(BytesIn in, size_t bytes, WriteCallbackFunc cb) override;
     void writeSome(BytesIn in, size_t bytes, WriteCallbackFunc cb) override;
 
     /// Initiates async readSome on connection

--- a/include/libp2p/security/noise/noise_connection.hpp
+++ b/include/libp2p/security/noise/noise_connection.hpp
@@ -53,8 +53,6 @@ namespace libp2p::connection {
     void deferReadCallback(outcome::result<size_t> res,
                            ReadCallbackFunc cb) override;
 
-    void write(BytesIn in, size_t bytes, WriteCallbackFunc cb) override;
-
     void writeSome(BytesIn in, size_t bytes, WriteCallbackFunc cb) override;
 
     void deferWriteCallback(std::error_code ec, WriteCallbackFunc cb) override;

--- a/include/libp2p/security/plaintext/plaintext_connection.hpp
+++ b/include/libp2p/security/plaintext/plaintext_connection.hpp
@@ -42,8 +42,6 @@ namespace libp2p::connection {
     void deferReadCallback(outcome::result<size_t> res,
                            ReadCallbackFunc cb) override;
 
-    void write(BytesIn in, size_t bytes, WriteCallbackFunc cb) override;
-
     void writeSome(BytesIn in, size_t bytes, WriteCallbackFunc cb) override;
 
     void deferWriteCallback(std::error_code ec, WriteCallbackFunc cb) override;

--- a/include/libp2p/security/secio/secio_connection.hpp
+++ b/include/libp2p/security/secio/secio_connection.hpp
@@ -103,8 +103,6 @@ namespace libp2p::connection {
     void deferReadCallback(outcome::result<size_t> res,
                            ReadCallbackFunc cb) override;
 
-    void write(BytesIn in, size_t bytes, WriteCallbackFunc cb) override;
-
     void writeSome(BytesIn in, size_t bytes, WriteCallbackFunc cb) override;
 
     void deferWriteCallback(std::error_code ec, WriteCallbackFunc cb) override;

--- a/include/libp2p/transport/tcp/tcp_connection.hpp
+++ b/include/libp2p/transport/tcp/tcp_connection.hpp
@@ -95,8 +95,6 @@ namespace libp2p::transport {
     void deferReadCallback(outcome::result<size_t> res,
                            ReadCallbackFunc cb) override;
 
-    void write(BytesIn in, size_t bytes, WriteCallbackFunc cb) override;
-
     void writeSome(BytesIn in, size_t bytes, WriteCallbackFunc cb) override;
 
     void deferWriteCallback(std::error_code ec, WriteCallbackFunc cb) override;

--- a/src/basic/message_read_writer_bigendian.cpp
+++ b/src/basic/message_read_writer_bigendian.cpp
@@ -11,6 +11,7 @@
 #include <arpa/inet.h>
 #include <boost/assert.hpp>
 #include <libp2p/basic/message_read_writer_error.hpp>
+#include <libp2p/basic/write_return_size.hpp>
 #include <libp2p/common/byteutil.hpp>
 
 namespace libp2p::basic {
@@ -55,13 +56,14 @@ namespace libp2p::basic {
     raw_buf.reserve(kLenMarkerSize + buffer.size());
     common::putUint32BE(raw_buf, buffer.size());
     raw_buf.insert(raw_buf.end(), buffer.begin(), buffer.end());
-    conn_->write(raw_buf,
-                 raw_buf.size(),
-                 [self{shared_from_this()}, cb{std::move(cb)}](auto &&result) {
-                   if (not result) {
-                     return cb(result.error());
-                   }
-                   cb(result.value() - self->kLenMarkerSize);
-                 });
+    writeReturnSize(
+        conn_,
+        raw_buf,
+        [self{shared_from_this()}, cb{std::move(cb)}](auto &&result) {
+          if (not result) {
+            return cb(result.error());
+          }
+          cb(result.value() - self->kLenMarkerSize);
+        });
   }
 }  // namespace libp2p::basic

--- a/src/connection/loopback_stream.cpp
+++ b/src/connection/loopback_stream.cpp
@@ -7,7 +7,6 @@
 #include <libp2p/connection/loopback_stream.hpp>
 
 #include <libp2p/basic/read_return_size.hpp>
-#include <libp2p/basic/write_return_size.hpp>
 #include <libp2p/common/ambigous_size.hpp>
 
 namespace libp2p::connection {
@@ -83,13 +82,6 @@ namespace libp2p::connection {
                             libp2p::basic::Reader::ReadCallbackFunc cb) {
     ambigousSize(out, bytes);
     readReturnSize(shared_from_this(), out, std::move(cb));
-  }
-
-  void LoopbackStream::write(BytesIn in,
-                             size_t bytes,
-                             libp2p::basic::Writer::WriteCallbackFunc cb) {
-    ambigousSize(in, bytes);
-    writeReturnSize(shared_from_this(), in, std::move(cb));
   }
 
   void LoopbackStream::writeSome(BytesIn in,

--- a/src/layer/websocket/ssl_connection.cpp
+++ b/src/layer/websocket/ssl_connection.cpp
@@ -7,7 +7,6 @@
 #include <libp2p/layer/websocket/ssl_connection.hpp>
 
 #include <libp2p/basic/read_return_size.hpp>
-#include <libp2p/basic/write_return_size.hpp>
 #include <libp2p/common/ambigous_size.hpp>
 #include <libp2p/common/asio_buffer.hpp>
 #include <libp2p/common/asio_cb.hpp>
@@ -56,13 +55,6 @@ namespace libp2p::connection {
                                libp2p::basic::Reader::ReadCallbackFunc cb) {
     ambigousSize(out, bytes);
     ssl_.async_read_some(asioBuffer(out), toAsioCbSize(std::move(cb)));
-  }
-
-  void SslConnection::write(BytesIn in,
-                            size_t bytes,
-                            libp2p::basic::Writer::WriteCallbackFunc cb) {
-    ambigousSize(in, bytes);
-    writeReturnSize(shared_from_this(), in, std::move(cb));
   }
 
   void SslConnection::writeSome(BytesIn in,

--- a/src/layer/websocket/ws_connection.cpp
+++ b/src/layer/websocket/ws_connection.cpp
@@ -7,7 +7,6 @@
 #include <libp2p/layer/websocket/ws_connection.hpp>
 
 #include <libp2p/basic/read_return_size.hpp>
-#include <libp2p/basic/write_return_size.hpp>
 #include <libp2p/common/ambigous_size.hpp>
 #include <libp2p/common/asio_buffer.hpp>
 #include <libp2p/common/asio_cb.hpp>
@@ -154,14 +153,6 @@ namespace libp2p::connection {
       }
     };
     ws_.async_read_some(asioBuffer(out), std::move(on_read));
-  }
-
-  void WsConnection::write(BytesIn in,    //
-                           size_t bytes,  //
-                           libp2p::basic::Writer::WriteCallbackFunc cb) {
-    ambigousSize(in, bytes);
-    SL_TRACE(log_, "write {} bytes", bytes);
-    writeReturnSize(shared_from_this(), in, std::move(cb));
   }
 
   void WsConnection::writeSome(BytesIn in,    //

--- a/src/muxer/mplex/mplex_stream.cpp
+++ b/src/muxer/mplex/mplex_stream.cpp
@@ -88,11 +88,6 @@ namespace libp2p::connection {
     }
   }
 
-  void MplexStream::write(BytesIn in, size_t bytes, WriteCallbackFunc cb) {
-    ambigousSize(in, bytes);
-    writeReturnSize(shared_from_this(), in, std::move(cb));
-  }
-
   void MplexStream::writeSome(BytesIn in, size_t bytes, WriteCallbackFunc cb) {
     ambigousSize(in, bytes);
     // TODO(107): Reentrancy

--- a/src/muxer/mplex/mplex_stream.cpp
+++ b/src/muxer/mplex/mplex_stream.cpp
@@ -94,6 +94,7 @@ namespace libp2p::connection {
   }
 
   void MplexStream::writeSome(BytesIn in, size_t bytes, WriteCallbackFunc cb) {
+    ambigousSize(in, bytes);
     // TODO(107): Reentrancy
 
     if (is_reset_) {
@@ -135,7 +136,7 @@ namespace libp2p::connection {
           if (not self->write_queue_.empty()) {
             auto [in, bytes, cb] = self->write_queue_.front();
             self->write_queue_.pop_front();
-            self->write(in, bytes, cb);
+            writeReturnSize(self, in, cb);
           }
         });
   }

--- a/src/muxer/mplex/mplexed_connection.cpp
+++ b/src/muxer/mplex/mplexed_connection.cpp
@@ -7,6 +7,7 @@
 #include <libp2p/muxer/mplex/mplexed_connection.hpp>
 
 #include <boost/assert.hpp>
+#include <libp2p/basic/write_return_size.hpp>
 #include <libp2p/muxer/mplex/mplex_frame.hpp>
 
 namespace libp2p::connection {
@@ -177,10 +178,8 @@ namespace libp2p::connection {
 
     is_writing_ = true;
     const auto &write_data = write_queue_.front();
-    return connection_->write(
-        write_data.data,
-        write_data.data.size(),
-        [self{shared_from_this()}](auto &&res) {
+    return writeReturnSize(
+        connection_, write_data.data, [self{shared_from_this()}](auto &&res) {
           self->onWriteCompleted(std::forward<decltype(res)>(res));
         });
   }

--- a/src/muxer/mplex/mplexed_connection.cpp
+++ b/src/muxer/mplex/mplexed_connection.cpp
@@ -136,12 +136,6 @@ namespace libp2p::connection {
     connection_->readSome(out, bytes, std::move(cb));
   }
 
-  void MplexedConnection::write(BytesIn in,
-                                size_t bytes,
-                                WriteCallbackFunc cb) {
-    connection_->write(in, bytes, std::move(cb));
-  }
-
   void MplexedConnection::writeSome(BytesIn in,
                                     size_t bytes,
                                     WriteCallbackFunc cb) {

--- a/src/muxer/yamux/yamux_stream.cpp
+++ b/src/muxer/yamux/yamux_stream.cpp
@@ -9,7 +9,6 @@
 #include <cassert>
 
 #include <libp2p/basic/read_return_size.hpp>
-#include <libp2p/basic/write_return_size.hpp>
 #include <libp2p/common/ambigous_size.hpp>
 #include <libp2p/muxer/yamux/yamux_frame.hpp>
 
@@ -66,11 +65,6 @@ namespace libp2p::connection {
         cb(res);
       }
     });
-  }
-
-  void YamuxStream::write(BytesIn in, size_t bytes, WriteCallbackFunc cb) {
-    ambigousSize(in, bytes);
-    writeReturnSize(shared_from_this(), in, std::move(cb));
   }
 
   void YamuxStream::writeSome(BytesIn in, size_t bytes, WriteCallbackFunc cb) {

--- a/src/muxer/yamux/yamuxed_connection.cpp
+++ b/src/muxer/yamux/yamuxed_connection.cpp
@@ -210,13 +210,6 @@ namespace libp2p::connection {
     deferReadCallback(Error::CONNECTION_DIRECT_IO_FORBIDDEN, std::move(cb));
   }
 
-  void YamuxedConnection::write(BytesIn in,
-                                size_t bytes,
-                                WriteCallbackFunc cb) {
-    log()->error("YamuxedConnection::write : invalid direct call");
-    deferWriteCallback(Error::CONNECTION_DIRECT_IO_FORBIDDEN, std::move(cb));
-  }
-
   void YamuxedConnection::writeSome(BytesIn in,
                                     size_t bytes,
                                     WriteCallbackFunc cb) {

--- a/src/protocol/echo/client_echo_session.cpp
+++ b/src/protocol/echo/client_echo_session.cpp
@@ -8,6 +8,7 @@
 
 #include <boost/assert.hpp>
 
+#include <libp2p/basic/write_return_size.hpp>
 #include <libp2p/log/logger.hpp>
 
 namespace libp2p::protocol {
@@ -32,7 +33,7 @@ namespace libp2p::protocol {
 
     auto self{shared_from_this()};
 
-    stream_->write(buf_, buf_.size(), [self](outcome::result<size_t> rw) {
+    writeReturnSize(stream_, buf_, [self](outcome::result<size_t> rw) {
       if (!rw && !self->ec_) {
         self->ec_ = rw.error();
         self->completed();

--- a/src/protocol/echo/server_echo_session.cpp
+++ b/src/protocol/echo/server_echo_session.cpp
@@ -8,6 +8,8 @@
 
 #include <boost/assert.hpp>
 
+#include <libp2p/basic/write_return_size.hpp>
+
 namespace libp2p::protocol {
 
   ServerEchoSession::ServerEchoSession(
@@ -81,9 +83,9 @@ namespace libp2p::protocol {
         // NOLINTNEXTLINE(cppcoreguidelines-narrowing-conversions)
         buf_.begin() + size);
     BytesIn span = write_buf;
-    stream_->write(
+    writeReturnSize(
+        stream_,
         span,
-        size,
         [self{shared_from_this()}, write_buf{std::move(write_buf)}](
             outcome::result<size_t> rwrite) { self->onWrite(rwrite); });
   }

--- a/src/protocol/kademlia/impl/session.cpp
+++ b/src/protocol/kademlia/impl/session.cpp
@@ -7,6 +7,7 @@
 #include <libp2p/protocol/kademlia/impl/session.hpp>
 
 #include <libp2p/basic/varint_reader.hpp>
+#include <libp2p/basic/write_return_size.hpp>
 #include <libp2p/protocol/kademlia/error.hpp>
 #include <libp2p/protocol/kademlia/impl/find_peer_executor.hpp>
 #include <libp2p/protocol/kademlia/message.hpp>
@@ -61,15 +62,14 @@ namespace libp2p::protocol::kademlia {
 
     ++writing_;
 
-    // NOLINTNEXTLINE(cppcoreguidelines-narrowing-conversions)
-    stream_->write(*buffer,
-                   buffer->size(),
-                   [wp = weak_from_this(), buffer, response_handler](
-                       outcome::result<size_t> result) {
-                     if (auto self = wp.lock()) {
-                       self->onMessageWritten(result, response_handler);
-                     }
-                   });
+    writeReturnSize(stream_,
+                    *buffer,
+                    [wp = weak_from_this(), buffer, response_handler](
+                        outcome::result<size_t> result) {
+                      if (auto self = wp.lock()) {
+                        self->onMessageWritten(result, response_handler);
+                      }
+                    });
 
     setResponseTimeout(response_handler);
     return true;

--- a/src/protocol/ping/ping_server_session.cpp
+++ b/src/protocol/ping/ping_server_session.cpp
@@ -7,6 +7,7 @@
 #include <libp2p/protocol/ping/ping_server_session.hpp>
 
 #include <boost/assert.hpp>
+#include <libp2p/basic/write_return_size.hpp>
 #include <libp2p/protocol/ping/common.hpp>
 
 namespace libp2p::protocol {
@@ -49,14 +50,13 @@ namespace libp2p::protocol {
       return;
     }
 
-    stream_->write(buffer_,
-                   config_.message_size,
-                   [self{shared_from_this()}](auto &&write_res) {
-                     if (!write_res) {
-                       return;
-                     }
-                     self->writeCompleted();
-                   });
+    writeReturnSize(
+        stream_, buffer_, [self{shared_from_this()}](auto &&write_res) {
+          if (!write_res) {
+            return;
+          }
+          self->writeCompleted();
+        });
   }
 
   void PingServerSession::writeCompleted() {

--- a/src/protocol_muxer/multiselect/multiselect_instance.cpp
+++ b/src/protocol_muxer/multiselect/multiselect_instance.cpp
@@ -8,6 +8,7 @@
 
 #include <cctype>
 
+#include <libp2p/basic/write_return_size.hpp>
 #include <libp2p/common/hexutil.hpp>
 #include <libp2p/common/trace.hpp>
 #include <libp2p/protocol_muxer/multiselect/serializing.hpp>
@@ -131,17 +132,16 @@ namespace libp2p::protocol_muxer::multiselect {
 
     SL_TRACE(log(), "sending {}", common::dumpBin(span));
 
-    connection_->write(
-        span,
-        span.size(),
-        [wptr = weak_from_this(),
-         round = current_round_,
-         packet = std::move(packet)](outcome::result<size_t> res) {
-          auto self = wptr.lock();
-          if (self && self->current_round_ == round) {
-            self->onDataWritten(res);
-          }
-        });
+    writeReturnSize(connection_,
+                    span,
+                    [wptr = weak_from_this(),
+                     round = current_round_,
+                     packet = std::move(packet)](outcome::result<size_t> res) {
+                      auto self = wptr.lock();
+                      if (self && self->current_round_ == round) {
+                        self->onDataWritten(res);
+                      }
+                    });
 
     is_writing_ = true;
   }

--- a/src/protocol_muxer/multiselect/simple_stream_negotiate.cpp
+++ b/src/protocol_muxer/multiselect/simple_stream_negotiate.cpp
@@ -6,6 +6,7 @@
 
 #include <libp2p/protocol_muxer/multiselect/simple_stream_negotiate.hpp>
 
+#include <libp2p/basic/write_return_size.hpp>
 #include <libp2p/common/hexutil.hpp>
 #include <libp2p/log/logger.hpp>
 #include <libp2p/protocol_muxer/multiselect/serializing.hpp>
@@ -140,9 +141,9 @@ namespace libp2p::protocol_muxer::multiselect {
 
     SL_TRACE(log(), "sending {}", common::dumpBin(span));
 
-    stream->write(
+    writeReturnSize(
+        stream,
         span,
-        span.size(),
         [stream = stream, cb = std::move(cb), buffers = std::move(buffers)](
             outcome::result<size_t> res) mutable {
           onPacketWritten(

--- a/src/security/noise/insecure_rw.cpp
+++ b/src/security/noise/insecure_rw.cpp
@@ -8,6 +8,7 @@
 
 #include <libp2p/security/noise/insecure_rw.hpp>
 
+#include <libp2p/basic/write_return_size.hpp>
 #include <libp2p/common/byteutil.hpp>
 #include <libp2p/security/noise/crypto/state.hpp>
 
@@ -73,6 +74,6 @@ namespace libp2p::security::noise {
       }
       cb(written_bytes - kLengthPrefixSize);
     };
-    connection_->write(outbuf_, outbuf_.size(), std::move(write_cb));
+    writeReturnSize(connection_, outbuf_, std::move(write_cb));
   }
 }  // namespace libp2p::security::noise

--- a/src/security/noise/noise_connection.cpp
+++ b/src/security/noise/noise_connection.cpp
@@ -7,7 +7,6 @@
 #include <libp2p/security/noise/noise_connection.hpp>
 
 #include <libp2p/basic/read_return_size.hpp>
-#include <libp2p/basic/write_return_size.hpp>
 #include <libp2p/common/ambigous_size.hpp>
 #include <libp2p/crypto/x25519_provider/x25519_provider_impl.hpp>
 #include <libp2p/security/noise/crypto/interfaces.hpp>
@@ -99,13 +98,6 @@ namespace libp2p::connection {
           self->frame_buffer_->assign(decrypted.begin(), decrypted.end());
           self->readSome(out, bytes, ctx, std::move(cb));
         });
-  }
-
-  void NoiseConnection::write(BytesIn in,
-                              size_t bytes,
-                              libp2p::basic::Writer::WriteCallbackFunc cb) {
-    ambigousSize(in, bytes);
-    writeReturnSize(shared_from_this(), in, std::move(cb));
   }
 
   void NoiseConnection::write(BytesIn in,

--- a/src/security/plaintext/plaintext_connection.cpp
+++ b/src/security/plaintext/plaintext_connection.cpp
@@ -69,12 +69,6 @@ namespace libp2p::connection {
     return original_connection_->readSome(in, bytes, std::move(f));
   };
 
-  void PlaintextConnection::write(BytesIn in,
-                                  size_t bytes,
-                                  Writer::WriteCallbackFunc f) {
-    return original_connection_->write(in, bytes, std::move(f));
-  }
-
   void PlaintextConnection::writeSome(BytesIn in,
                                       size_t bytes,
                                       Writer::WriteCallbackFunc f) {

--- a/src/security/secio/secio.cpp
+++ b/src/security/secio/secio.cpp
@@ -8,6 +8,7 @@
 
 #include <generated/security/secio/protobuf/secio.pb.h>
 #include <libp2p/basic/protobuf_message_read_writer.hpp>
+#include <libp2p/basic/write_return_size.hpp>
 #include <libp2p/crypto/sha/sha256.hpp>
 #include <libp2p/security/error.hpp>
 #include <libp2p/security/secio/secio_connection.hpp>
@@ -254,9 +255,9 @@ namespace libp2p::security {
               local_stretched_key,
               remote_stretched_key);
           SECIO_OUTCOME_VOID_TRY(secio_conn->init(), conn, cb)
-          secio_conn->write(
+          writeReturnSize(
+              secio_conn,
               self->remote_peer_rand_,
-              self->remote_peer_rand_.size(),
               [self, conn, cb, secio_conn](auto &&write_res) {
                 SECIO_OUTCOME_TRY(written_bytes, write_res, conn, cb)
                 if (written_bytes != self->remote_peer_rand_.size()) {

--- a/src/security/secio/secio_connection.cpp
+++ b/src/security/secio/secio_connection.cpp
@@ -310,13 +310,6 @@ namespace libp2p::connection {
         });
   }
 
-  void SecioConnection::write(BytesIn in,
-                              size_t bytes,
-                              basic::Writer::WriteCallbackFunc cb) {
-    ambigousSize(in, bytes);
-    writeReturnSize(shared_from_this(), in, std::move(cb));
-  }
-
   void SecioConnection::writeSome(BytesIn in,
                                   size_t bytes,
                                   basic::Writer::WriteCallbackFunc cb) {

--- a/src/security/secio/secio_connection.cpp
+++ b/src/security/secio/secio_connection.cpp
@@ -351,7 +351,7 @@ namespace libp2p::connection {
           }
           user_cb(bytes);
         };
-    original_connection_->write(frame_buffer, frame_buffer.size(), cb_wrapper);
+    writeReturnSize(original_connection_, frame_buffer, cb_wrapper);
   }
 
   bool SecioConnection::isClosed() const {

--- a/src/security/tls/tls_connection.cpp
+++ b/src/security/tls/tls_connection.cpp
@@ -8,7 +8,6 @@
 #include "tls_details.hpp"
 
 #include <libp2p/basic/read_return_size.hpp>
-#include <libp2p/basic/write_return_size.hpp>
 #include <libp2p/common/ambigous_size.hpp>
 
 namespace libp2p::connection {
@@ -167,14 +166,6 @@ namespace libp2p::connection {
   void TlsConnection::deferReadCallback(outcome::result<size_t> res,
                                         Reader::ReadCallbackFunc cb) {
     original_connection_->deferReadCallback(res, std::move(cb));
-  }
-
-  void TlsConnection::write(BytesIn in,
-                            size_t bytes,
-                            Writer::WriteCallbackFunc cb) {
-    ambigousSize(in, bytes);
-    SL_TRACE(log(), "writing {} bytes", bytes);
-    writeReturnSize(shared_from_this(), in, std::move(cb));
   }
 
   void TlsConnection::writeSome(BytesIn in,

--- a/src/security/tls/tls_connection.hpp
+++ b/src/security/tls/tls_connection.hpp
@@ -90,9 +90,6 @@ namespace libp2p::connection {
     void deferReadCallback(outcome::result<size_t> res,
                            ReadCallbackFunc cb) override;
 
-    /// Async writes exactly the # of bytes given
-    void write(BytesIn in, size_t bytes, WriteCallbackFunc cb) override;
-
     /// Async writes up to the # of bytes given
     void writeSome(BytesIn in, size_t bytes, WriteCallbackFunc cb) override;
 

--- a/src/transport/tcp/tcp_connection.cpp
+++ b/src/transport/tcp/tcp_connection.cpp
@@ -7,7 +7,6 @@
 #include <libp2p/transport/tcp/tcp_connection.hpp>
 
 #include <libp2p/basic/read_return_size.hpp>
-#include <libp2p/basic/write_return_size.hpp>
 #include <libp2p/common/ambigous_size.hpp>
 #include <libp2p/transport/tcp/tcp_util.hpp>
 
@@ -239,14 +238,6 @@ namespace libp2p::transport {
     TRACE("{} read some up to {}", debug_str_, bytes);
     socket_.async_read_some(detail::makeBuffer(out, bytes),
                             closeOnError(*this, std::move(cb)));
-  }
-
-  void TcpConnection::write(BytesIn in,
-                            size_t bytes,
-                            TcpConnection::WriteCallbackFunc cb) {
-    ambigousSize(in, bytes);
-    TRACE("{} write {}", debug_str_, bytes);
-    writeReturnSize(shared_from_this(), in, std::move(cb));
   }
 
   void TcpConnection::writeSome(BytesIn in,

--- a/test/acceptance/p2p/host/protocol/client_test_session.cpp
+++ b/test/acceptance/p2p/host/protocol/client_test_session.cpp
@@ -7,6 +7,7 @@
 
 #include <gtest/gtest.h>
 #include <boost/assert.hpp>
+#include <libp2p/basic/write_return_size.hpp>
 #include "libp2p/crypto/random_generator/boost_generator.hpp"
 
 namespace libp2p::protocol {
@@ -35,16 +36,16 @@ namespace libp2p::protocol {
 
     write_buf_ = random_generator_->randomBytes(buffer_size_);
 
-    stream_->write(write_buf_,
-                   buffer_size_,
-                   [self = shared_from_this(),
-                    cb{std::move(cb)}](outcome::result<size_t> rw) mutable {
-                     if (!rw) {
-                       return cb(rw.error());
-                     }
+    writeReturnSize(stream_,
+                    write_buf_,
+                    [self = shared_from_this(),
+                     cb{std::move(cb)}](outcome::result<size_t> rw) mutable {
+                      if (!rw) {
+                        return cb(rw.error());
+                      }
 
-                     self->read(cb);
-                   });
+                      self->read(cb);
+                    });
   }
 
   void ClientTestSession::read(Callback cb) {

--- a/test/acceptance/p2p/muxer.cpp
+++ b/test/acceptance/p2p/muxer.cpp
@@ -12,6 +12,7 @@
 #include <gtest/gtest.h>
 #include <libp2p/basic/scheduler/asio_scheduler_backend.hpp>
 #include <libp2p/basic/scheduler/scheduler_impl.hpp>
+#include <libp2p/basic/write_return_size.hpp>
 #include <libp2p/common/literals.hpp>
 #include <libp2p/connection/stream.hpp>
 #include <libp2p/crypto/key_marshaller/key_marshaller_impl.hpp>
@@ -144,9 +145,10 @@ struct Server : public std::enable_shared_from_this<Server> {
           this->streamReads++;
 
           // 01-echo back read data
-          stream->write(
+          buf->resize(read);
+          writeReturnSize(
+              stream,
               *buf,
-              read,
               [buf, read, stream, this](outcome::result<size_t> rwrite) {
                 EXPECT_OUTCOME_TRUE(write, rwrite)
                 this->println("write ", write, " bytes");
@@ -242,9 +244,9 @@ struct Client : public std::enable_shared_from_this<Client> {
     }
 
     auto buf = randomBuffer();
-    stream->write(
+    writeReturnSize(
+        stream,
         *buf,
-        buf->size(),
         [round, streamId, buf, stream, this](outcome::result<size_t> rwrite) {
           EXPECT_OUTCOME_TRUE(write, rwrite);
           this->println(streamId, " write ", write, " bytes");

--- a/test/libp2p/basic/message_read_writer_test.cpp
+++ b/test/libp2p/basic/message_read_writer_test.cpp
@@ -73,7 +73,7 @@ ACTION_P2(CheckWrite, buf, varint) {
 }
 
 TEST_F(MessageReadWriterTest, Write) {
-  EXPECT_CALL(*conn_mock_, write(_, kMsgLength + 1, _))
+  EXPECT_CALL(*conn_mock_, writeSome(_, kMsgLength + 1, _))
       .WillOnce(CheckWrite(msg_with_varint_bytes_, len_varint_));
 
   msg_rw_->write(msg_bytes_, [this](auto &&res) {

--- a/test/libp2p/connection/loopback_stream/loopback_stream_test.cpp
+++ b/test/libp2p/connection/loopback_stream/loopback_stream_test.cpp
@@ -8,6 +8,7 @@
 
 #include <gtest/gtest.h>
 #include <boost/asio/io_context.hpp>  // clang-format puts it here, sorry ¯\_(ツ)_/¯
+#include <libp2p/basic/write_return_size.hpp>
 #include <libp2p/crypto/key_marshaller/key_marshaller_impl.hpp>
 #include <libp2p/multi/multibase_codec/codecs/base58.hpp>
 #include <testutil/outcome.hpp>
@@ -49,10 +50,8 @@ TEST_F(LoopbackStreamTest, Basic) {
   std::shared_ptr<libp2p::connection::Stream> stream =
       std::make_shared<LoopbackStream>(PeerInfo{peer_id, {}}, context);
   bool all_executed{false};
-  stream->write(
-      kBuffer,
-      kBuffer.size(),
-      [stream, buf = kBuffer, &all_executed](auto result) {
+  libp2p::writeReturnSize(
+      stream, kBuffer, [stream, buf = kBuffer, &all_executed](auto result) {
         EXPECT_OUTCOME_TRUE(bytes, result);
         ASSERT_EQ(bytes, kBufferSize);
         auto read_buf = std::make_shared<Buffer>(kBufferSize, 0);

--- a/test/libp2p/connection/security_conn/plaintext_connection_test.cpp
+++ b/test/libp2p/connection/security_conn/plaintext_connection_test.cpp
@@ -7,6 +7,7 @@
 #include <libp2p/security/plaintext/plaintext_connection.hpp>
 
 #include <gtest/gtest.h>
+#include <libp2p/basic/write_return_size.hpp>
 #include <libp2p/common/literals.hpp>
 #include <testutil/outcome.hpp>
 #include "mock/libp2p/connection/layer_connection_mock.hpp"
@@ -152,9 +153,9 @@ TEST_F(PlaintextConnectionTest, ReadSome) {
  */
 TEST_F(PlaintextConnectionTest, Write) {
   const int size = 100;
-  EXPECT_CALL(*connection_, write(_, _, _)).WillOnce(AsioSuccess(size));
+  EXPECT_CALL(*connection_, writeSome(_, _, _)).WillOnce(AsioSuccess(size));
   auto buf = std::make_shared<std::vector<uint8_t>>(size, 0);
-  secure_connection_->write(*buf, size, [size, buf](auto &&res) {
+  libp2p::writeReturnSize(secure_connection_, *buf, [size, buf](auto &&res) {
     ASSERT_TRUE(res) << res.error().message();
     ASSERT_EQ(res.value(), size);
   });

--- a/test/libp2p/muxer/muxers_and_streams_test.cpp
+++ b/test/libp2p/muxer/muxers_and_streams_test.cpp
@@ -10,6 +10,7 @@
 #include <gtest/gtest.h>
 #include <boost/di/extension/scopes/shared.hpp>
 
+#include <libp2p/basic/write_return_size.hpp>
 #include <libp2p/injector/host_injector.hpp>
 
 #define TRACE_ENABLED 1
@@ -190,8 +191,9 @@ namespace libp2p::regression {
         return behavior_(*this);
       }
       // clang-format off
-      stream->write(
-          *write_buf_, write_buf_->size(),
+      writeReturnSize(
+          stream,
+          *write_buf_,
           [wptr = weak_from_this(), buf = write_buf_] (auto res) {
             auto self = wptr.lock();
             if (self) {  self->onWrite(res); }

--- a/test/libp2p/protocol/echo_test.cpp
+++ b/test/libp2p/protocol/echo_test.cpp
@@ -65,7 +65,7 @@ TEST(EchoTest, Server) {
       .WillOnce(Arg0CallbackWithArg(outcome::success()));
 
   EXPECT_CALL(*stream, readSome(_, _, _)).WillOnce(SetReadMsg(msg));
-  EXPECT_CALL(*stream, write(_, _, _)).WillOnce(WriteMsgAssertEqual(msg));
+  EXPECT_CALL(*stream, writeSome(_, _, _)).WillOnce(WriteMsgAssertEqual(msg));
 
   echo.handle(StreamAndProtocol{stream, {}});
 }
@@ -82,7 +82,7 @@ TEST(EchoTest, DISABLED_Client) {
 
   EXPECT_CALL(*stream, isClosedForWrite()).WillOnce(Return(false));
 
-  EXPECT_CALL(*stream, write(_, _, _)).WillOnce(WriteMsgAssertEqual(msg));
+  EXPECT_CALL(*stream, writeSome(_, _, _)).WillOnce(WriteMsgAssertEqual(msg));
   EXPECT_CALL(*stream, readSome(_, _, _)).WillOnce(WriteMsgAssertEqual(msg));
 
   bool executed = false;

--- a/test/libp2p/protocol/identify_delta_test.cpp
+++ b/test/libp2p/protocol/identify_delta_test.cpp
@@ -135,7 +135,7 @@ TEST_F(IdentifyDeltaTest, Send) {
   };
 
   EXPECT_CALL(*stream_,
-              write(Truly(if_added), msg_added_protos_bytes_.size(), _))
+              writeSome(Truly(if_added), msg_added_protos_bytes_.size(), _))
       .WillOnce(InvokeArgument<2>(outcome::success()));
 
   id_delta_->start();

--- a/test/libp2p/protocol/identify_test.cpp
+++ b/test/libp2p/protocol/identify_test.cpp
@@ -183,7 +183,7 @@ TEST_F(IdentifyTest, Send) {
   EXPECT_CALL(host_, getLibp2pClientVersion()).WillOnce(Return(kClientVersion));
 
   // handle Identify request and check it
-  EXPECT_CALL(*stream_, write(_, _, _))
+  EXPECT_CALL(*stream_, writeSome(_, _, _))
       .WillOnce(Success(
           BytesIn(identify_pb_msg_bytes_.data(), identify_pb_msg_bytes_.size()),
           outcome::success(identify_pb_msg_bytes_.size())));

--- a/test/libp2p/protocol/ping_test.cpp
+++ b/test/libp2p/protocol/ping_test.cpp
@@ -86,7 +86,7 @@ TEST_F(PingTest, PingServer) {
     return std::equal(
         actual.begin(), actual.end(), expected.begin(), expected.end());
   };
-  EXPECT_CALL(*stream_, write(Truly(if_eq_buf), kPingMsgSize, _))
+  EXPECT_CALL(*stream_, writeSome(Truly(if_eq_buf), kPingMsgSize, _))
       .WillOnce(InvokeArgument<2>(buffer_.size()));
 
   EXPECT_CALL(*stream_, isClosedForWrite()).WillOnce(Return(false));
@@ -117,7 +117,7 @@ TEST_F(PingTest, PingClient) {
     return std::equal(
         actual.begin(), actual.end(), expected.begin(), expected.end());
   };
-  EXPECT_CALL(*stream_, write(Truly(if_eq_buf), kPingMsgSize, _))
+  EXPECT_CALL(*stream_, writeSome(Truly(if_eq_buf), kPingMsgSize, _))
       .WillOnce(InvokeArgument<2>(buffer_.size()))
       .WillOnce(  // no second write
           InvokeArgument<2>(outcome::failure(boost::system::error_code{
@@ -156,7 +156,7 @@ TEST_F(PingTest, PingClientTimeoutExpired) {
     return std::equal(
         actual.begin(), actual.end(), expected.begin(), expected.end());
   };
-  EXPECT_CALL(*stream_, write(Truly(if_eq_buf), kPingMsgSize, _));
+  EXPECT_CALL(*stream_, writeSome(Truly(if_eq_buf), kPingMsgSize, _));
 
   EXPECT_CALL(*stream_, isClosedForWrite()).WillOnce(Return(false));
 

--- a/test/libp2p/security/plaintext_adaptor_test.cpp
+++ b/test/libp2p/security/plaintext_adaptor_test.cpp
@@ -47,7 +47,7 @@ class PlaintextAdaptorTest : public testing::Test {
     adaptor = std::make_shared<Plaintext>(marshaller, idmgr, key_marshaller);
 
     ON_CALL(*conn, read(_, _, _)).WillByDefault(Arg2CallbackWithArg(5));
-    ON_CALL(*conn, write(_, _, _)).WillByDefault(Arg2CallbackWithArg(5));
+    ON_CALL(*conn, writeSome(_, _, _)).WillByDefault(Arg2CallbackWithArg(5));
 
     ON_CALL(*idmgr, getKeyPair()).WillByDefault(ReturnRef(local_keypair));
     ON_CALL(*idmgr, getId()).WillByDefault(ReturnRef(local_pid));

--- a/test/mock/libp2p/basic/read_writer_mock.hpp
+++ b/test/mock/libp2p/basic/read_writer_mock.hpp
@@ -15,7 +15,6 @@ namespace libp2p::basic {
     MOCK_METHOD3(read, void(BytesOut, size_t, Reader::ReadCallbackFunc));
     MOCK_METHOD3(readSome, void(BytesOut, size_t, Reader::ReadCallbackFunc));
 
-    MOCK_METHOD3(write, void(BytesIn, size_t, Writer::WriteCallbackFunc));
     MOCK_METHOD3(writeSome, void(BytesIn, size_t, Writer::WriteCallbackFunc));
   };
 }  // namespace libp2p::basic

--- a/test/mock/libp2p/basic/readwritecloser_mock.hpp
+++ b/test/mock/libp2p/basic/readwritecloser_mock.hpp
@@ -23,7 +23,6 @@ namespace libp2p::basic {
 
     MOCK_METHOD2(read, void(BytesOut, Reader::ReadCallbackFunc));
     MOCK_METHOD2(readSome, void(BytesOut, Reader::ReadCallbackFunc));
-    MOCK_METHOD2(write, void(BytesIn, Writer::WriteCallbackFunc));
     MOCK_METHOD2(writeSome, void(BytesIn, Writer::WriteCallbackFunc));
   };
 }  // namespace libp2p::basic

--- a/test/mock/libp2p/basic/writer_mock.hpp
+++ b/test/mock/libp2p/basic/writer_mock.hpp
@@ -15,7 +15,6 @@ namespace libp2p::basic {
    public:
     ~WriterMock() override = default;
 
-    MOCK_METHOD2(write, void(BytesIn, Writer::WriteCallbackFunc));
     MOCK_METHOD2(writeSome, void(BytesIn, Writer::WriteCallbackFunc));
   };
 }  // namespace libp2p::basic

--- a/test/mock/libp2p/connection/capable_connection_mock.hpp
+++ b/test/mock/libp2p/connection/capable_connection_mock.hpp
@@ -33,7 +33,6 @@ namespace libp2p::connection {
     MOCK_METHOD0(close, outcome::result<void>());
     MOCK_METHOD3(read, void(BytesOut, size_t, Reader::ReadCallbackFunc));
     MOCK_METHOD3(readSome, void(BytesOut, size_t, Reader::ReadCallbackFunc));
-    MOCK_METHOD3(write, void(BytesIn, size_t, Writer::WriteCallbackFunc));
     MOCK_METHOD3(writeSome, void(BytesIn, size_t, Writer::WriteCallbackFunc));
     MOCK_METHOD2(deferReadCallback,
                  void(outcome::result<size_t>, Reader::ReadCallbackFunc));
@@ -91,10 +90,6 @@ namespace libp2p::connection {
                   Reader::ReadCallbackFunc f) override {
       return real_->readSome(in, bytes, f);
     };
-
-    void write(BytesIn in, size_t bytes, Writer::WriteCallbackFunc f) override {
-      return real_->write(in, bytes, f);
-    }
 
     void writeSome(BytesIn in,
                    size_t bytes,

--- a/test/mock/libp2p/connection/layer_connection_mock.hpp
+++ b/test/mock/libp2p/connection/layer_connection_mock.hpp
@@ -22,7 +22,6 @@ namespace libp2p::connection {
 
     MOCK_METHOD3(read, void(BytesOut, size_t, Reader::ReadCallbackFunc));
     MOCK_METHOD3(readSome, void(BytesOut, size_t, Reader::ReadCallbackFunc));
-    MOCK_METHOD3(write, void(BytesIn, size_t, Writer::WriteCallbackFunc));
     MOCK_METHOD3(writeSome, void(BytesIn, size_t, Writer::WriteCallbackFunc));
     MOCK_METHOD2(deferReadCallback,
                  void(outcome::result<size_t>, Reader::ReadCallbackFunc));

--- a/test/mock/libp2p/connection/secure_connection_mock.hpp
+++ b/test/mock/libp2p/connection/secure_connection_mock.hpp
@@ -21,7 +21,6 @@ namespace libp2p::connection {
 
     MOCK_METHOD3(read, void(BytesOut, size_t, Reader::ReadCallbackFunc));
     MOCK_METHOD3(readSome, void(BytesOut, size_t, Reader::ReadCallbackFunc));
-    MOCK_METHOD3(write, void(BytesIn, size_t, Writer::WriteCallbackFunc));
     MOCK_METHOD3(writeSome, void(BytesIn, size_t, Writer::WriteCallbackFunc));
 
     MOCK_METHOD2(deferReadCallback,

--- a/test/mock/libp2p/connection/stream_mock.hpp
+++ b/test/mock/libp2p/connection/stream_mock.hpp
@@ -27,7 +27,6 @@ namespace libp2p::connection {
 
     MOCK_METHOD3(read, void(BytesOut, size_t, Reader::ReadCallbackFunc));
     MOCK_METHOD3(readSome, void(BytesOut, size_t, Reader::ReadCallbackFunc));
-    MOCK_METHOD3(write, void(BytesIn, size_t, Writer::WriteCallbackFunc));
     MOCK_METHOD3(writeSome, void(BytesIn, size_t, Writer::WriteCallbackFunc));
 
     MOCK_METHOD2(deferReadCallback,

--- a/test/testutil/libp2p/message_read_writer_helper.cpp
+++ b/test/testutil/libp2p/message_read_writer_helper.cpp
@@ -61,7 +61,7 @@ namespace libp2p::basic {
     msg.insert(msg.begin(),
                varint_to_write.toVector().begin(),
                varint_to_write.toVector().end());
-    EXPECT_CALL(*read_writer_mock, write(_, msg.size(), _))
+    EXPECT_CALL(*read_writer_mock, writeSome(_, msg.size(), _))
         .WillOnce(CheckBytes(msg));
   }
 
@@ -72,7 +72,7 @@ namespace libp2p::basic {
     msg.insert(msg.begin(),
                varint_to_write.toVector().begin(),
                varint_to_write.toVector().end());
-    EXPECT_CALL(*stream_mock, write(_, msg.size(), _))  // NOLINT
+    EXPECT_CALL(*stream_mock, writeSome(_, msg.size(), _))  // NOLINT
         .WillOnce(CheckBytes(msg));
   }
 }  // namespace libp2p::basic


### PR DESCRIPTION
- (#206)
- replace `Writer::write` with `write`/`writeReturnSize`
  - `writeReturnSize` doesn't change callback type to reduce changes to review
    - old usages may be simplified/refactored later in other pr's
- remove `Writer::write`
  - `Writer::write` can't get `shared_ptr` from `this`
    - `enable_shared_from_this` would conflict (`Reader`, `Writer`, user class)