### PR TITLE
multistream max

### DIFF
--- a/include/libp2p/basic/varint_prefix_reader.hpp
+++ b/include/libp2p/basic/varint_prefix_reader.hpp
@@ -42,6 +42,10 @@ namespace libp2p::basic {
       return value_;
     }
 
+    size_t size() const {
+      return got_bytes_;
+    }
+
     /// Resets reader's state
     void reset();
 

--- a/src/protocol_muxer/multiselect/parser.cpp
+++ b/src/protocol_muxer/multiselect/parser.cpp
@@ -11,6 +11,7 @@
 namespace libp2p::protocol_muxer::multiselect::detail {
 
   constexpr size_t kMaxRecursionDepth = 3;
+  constexpr size_t kMaxLenBytes = 2;
 
   size_t Parser::bytesNeeded() const {
     size_t n = 0;
@@ -44,9 +45,17 @@ namespace libp2p::protocol_muxer::multiselect::detail {
       if (expected_msg_size_ == 0) {
         auto s = varint_reader_.consume(data);
         if (s == VarintPrefixReader::kUnderflow) {
+          if (varint_reader_.size() >= kMaxLenBytes) {
+            state_ = kOverflow;
+            break;
+          }
           continue;
         }
         if (s != VarintPrefixReader::kReady) {
+          state_ = kOverflow;
+          break;
+        }
+        if (varint_reader_.size() > kMaxLenBytes) {
           state_ = kOverflow;
           break;
         }

--- a/src/protocol_muxer/multiselect/parser.cpp
+++ b/src/protocol_muxer/multiselect/parser.cpp
@@ -44,18 +44,18 @@ namespace libp2p::protocol_muxer::multiselect::detail {
 
       if (expected_msg_size_ == 0) {
         auto s = varint_reader_.consume(data);
+        if (varint_reader_.size() > kMaxLenBytes) {
+          state_ = kOverflow;
+          break;
+        }
         if (s == VarintPrefixReader::kUnderflow) {
-          if (varint_reader_.size() >= kMaxLenBytes) {
+          if (varint_reader_.size() == kMaxLenBytes) {
             state_ = kOverflow;
             break;
           }
           continue;
         }
         if (s != VarintPrefixReader::kReady) {
-          state_ = kOverflow;
-          break;
-        }
-        if (varint_reader_.size() > kMaxLenBytes) {
           state_ = kOverflow;
           break;
         }


### PR DESCRIPTION
- https://github.com/qdrvm/KAGOME-audit/issues/25

[`const MAX_LEN_BYTES: u16 = 2`](https://github.com/libp2p/rust-libp2p/blob/5ad9485bd402d0f16cb1d2b521bb4abed0938d7e/misc/multistream-select/src/length_delimited.rs#L31)