### PR TITLE
fix cmake 3.29 policy warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,8 @@ set(CMAKE_TOOLCHAIN_FILE
 
 cmake_policy(SET CMP0048 NEW)
 cmake_policy(SET CMP0135 NEW)
+cmake_policy(SET CMP0144 NEW)
+cmake_policy(SET CMP0153 OLD)
 
 include("cmake/Hunter/init.cmake")
 


### PR DESCRIPTION
This adds two new policies:

```
cmake_policy(SET CMP0144 NEW)
cmake_policy(SET CMP0153 OLD)
```

This quiets a few warnings generated when using cmake 3.29.