### PR TITLE
fix websocket transport

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,9 @@
 cmake_minimum_required(VERSION 3.12)
 
+if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.27")
+  cmake_policy(SET CMP0144 NEW)
+endif()
+
 find_program(CCACHE_FOUND ccache)
 if (CCACHE_FOUND)
   set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)

--- a/include/libp2p/multi/multiaddress.hpp
+++ b/include/libp2p/multi/multiaddress.hpp
@@ -19,6 +19,10 @@
 #include <libp2p/outcome/outcome.hpp>
 #include <span>
 
+namespace libp2p {
+  using ProtoAddrVec = std::vector<std::pair<multi::Protocol, std::string>>;
+}  // namespace libp2p
+
 namespace libp2p::multi {
 
   /**
@@ -148,8 +152,7 @@ namespace libp2p::multi {
      * @return list of pairs with a protocol as the first element and the value
      * as the second one
      */
-    std::vector<std::pair<Protocol, std::string>> getProtocolsWithValues()
-        const;
+    ProtoAddrVec getProtocolsWithValues() const;
 
     bool operator==(const Multiaddress &other) const;
 

--- a/include/libp2p/muxer/yamux/yamuxed_connection.hpp
+++ b/include/libp2p/muxer/yamux/yamuxed_connection.hpp
@@ -198,6 +198,8 @@ namespace libp2p::connection {
     /// True if waiting for current write operation to complete
     bool is_writing_ = false;
 
+    std::shared_ptr<Bytes> writing_buf_ = std::make_shared<Bytes>();
+
     /// Write queue
     std::deque<WriteQueueItem> write_queue_;
 

--- a/include/libp2p/transport/impl/upgrader_session.hpp
+++ b/include/libp2p/transport/impl/upgrader_session.hpp
@@ -19,7 +19,6 @@ namespace libp2p::transport {
    */
   struct UpgraderSession
       : public std::enable_shared_from_this<UpgraderSession> {
-    using ProtoAddrVec = std::vector<std::pair<multi::Protocol, std::string>>;
     using ConnectionCallback =
         void(outcome::result<std::shared_ptr<connection::CapableConnection>>);
     using HandlerFunc = std::function<ConnectionCallback>;

--- a/include/libp2p/transport/tcp/tcp_connection.hpp
+++ b/include/libp2p/transport/tcp/tcp_connection.hpp
@@ -39,9 +39,11 @@ namespace libp2p::transport {
     using ConnectCallback = void(const ErrorCode &, const Tcp::endpoint &);
     using ConnectCallbackFunc = std::function<ConnectCallback>;
 
-    explicit TcpConnection(boost::asio::io_context &ctx);
+    explicit TcpConnection(boost::asio::io_context &ctx, ProtoAddrVec layers);
 
-    TcpConnection(boost::asio::io_context &ctx, Tcp::socket &&socket);
+    TcpConnection(boost::asio::io_context &ctx,
+                  ProtoAddrVec layers,
+                  Tcp::socket &&socket);
 
     /**
      * @brief Resolve service name (DNS).
@@ -122,6 +124,7 @@ namespace libp2p::transport {
     outcome::result<void> saveMultiaddresses();
 
     boost::asio::io_context &context_;
+    ProtoAddrVec layers_;
     Tcp::socket socket_;
     bool initiator_ = false;
     bool connecting_with_timeout_ = false;

--- a/include/libp2p/transport/tcp/tcp_listener.hpp
+++ b/include/libp2p/transport/tcp/tcp_listener.hpp
@@ -20,8 +20,6 @@ namespace libp2p::transport {
   class TcpListener : public TransportListener,
                       public std::enable_shared_from_this<TcpListener> {
    public:
-    using ProtoAddrVec = std::vector<std::pair<multi::Protocol, std::string>>;
-
     ~TcpListener() override = default;
 
     TcpListener(boost::asio::io_context &context,

--- a/include/libp2p/transport/tcp/tcp_util.hpp
+++ b/include/libp2p/transport/tcp/tcp_util.hpp
@@ -18,9 +18,7 @@
 namespace libp2p::transport::detail {
   template <typename T>
   inline outcome::result<multi::Multiaddress> makeAddress(
-      T &&endpoint,
-      const std::vector<std::pair<multi::Protocol, std::string>> *layers =
-          nullptr) {
+      T &&endpoint, const ProtoAddrVec *layers = nullptr) {
     try {
       auto address = endpoint.address();
       auto port = endpoint.port();
@@ -98,8 +96,6 @@ namespace libp2p::transport::detail {
 
     return {host, port};
   }
-
-  using ProtoAddrVec = std::vector<std::pair<multi::Protocol, std::string>>;
 
   // Obtain layers string from provided address
   inline ProtoAddrVec getLayers(const multi::Multiaddress &address) {

--- a/include/libp2p/transport/upgrader.hpp
+++ b/include/libp2p/transport/upgrader.hpp
@@ -23,8 +23,6 @@ namespace libp2p::transport {
    * and using the chosen protocols to actually upgrade the connections
    */
   struct Upgrader {
-    using ProtoAddrVec = std::vector<std::pair<multi::Protocol, std::string>>;
-
     using RawSPtr = std::shared_ptr<connection::RawConnection>;
     using LayerSPtr = std::shared_ptr<connection::LayerConnection>;
     using SecSPtr = std::shared_ptr<connection::SecureConnection>;

--- a/src/muxer/yamux/yamuxed_connection.cpp
+++ b/src/muxer/yamux/yamuxed_connection.cpp
@@ -651,8 +651,9 @@ namespace libp2p::connection {
   void YamuxedConnection::doWrite(WriteQueueItem packet) {
     assert(!is_writing_);
 
-    auto span = BytesIn(packet.packet);
+    writing_buf_->assign(packet.packet.begin(), packet.packet.end());
     auto cb = [wptr{weak_from_this()},
+               buf{writing_buf_},
                packet = std::move(packet)](outcome::result<size_t> res) {
       if (auto self = wptr.lock()) {
         self->onDataWritten(res, packet.stream_id);
@@ -660,7 +661,7 @@ namespace libp2p::connection {
     };
 
     is_writing_ = true;
-    writeReturnSize(connection_, span, cb);
+    writeReturnSize(connection_, *writing_buf_, cb);
   }
 
   void YamuxedConnection::onDataWritten(outcome::result<size_t> res,

--- a/src/transport/tcp/tcp_connection.cpp
+++ b/src/transport/tcp/tcp_connection.cpp
@@ -31,16 +31,20 @@ namespace libp2p::transport {
   }  // namespace
 
   TcpConnection::TcpConnection(boost::asio::io_context &ctx,
+                               ProtoAddrVec layers,
                                boost::asio::ip::tcp::socket &&socket)
       : context_(ctx),
+        layers_{std::move(layers)},
         socket_(std::move(socket)),
         connection_phase_done_{false},
         deadline_timer_(context_) {
     std::ignore = saveMultiaddresses();
   }
 
-  TcpConnection::TcpConnection(boost::asio::io_context &ctx)
+  TcpConnection::TcpConnection(boost::asio::io_context &ctx,
+                               ProtoAddrVec layers)
       : context_(ctx),
+        layers_{std::move(layers)},
         socket_(context_),
         connection_phase_done_{false},
         deadline_timer_(context_) {}
@@ -292,15 +296,15 @@ namespace libp2p::transport {
       if (!local_multiaddress_) {
         auto endpoint(socket_.local_endpoint(ec));
         if (!ec) {
-          OUTCOME_TRY(addr, detail::makeAddress(endpoint));
-          local_multiaddress_ = std::move(addr);
+          BOOST_OUTCOME_TRY(local_multiaddress_,
+                            detail::makeAddress(endpoint, &layers_));
         }
       }
       if (!remote_multiaddress_) {
         auto endpoint(socket_.remote_endpoint(ec));
         if (!ec) {
-          OUTCOME_TRY(addr, detail::makeAddress(endpoint));
-          remote_multiaddress_ = std::move(addr);
+          BOOST_OUTCOME_TRY(remote_multiaddress_,
+                            detail::makeAddress(endpoint, &layers_));
         }
       }
     } else {

--- a/src/transport/tcp/tcp_listener.cpp
+++ b/src/transport/tcp/tcp_listener.cpp
@@ -96,8 +96,8 @@ namespace libp2p::transport {
             return self->handle_(ec);
           }
 
-          auto conn =
-              std::make_shared<TcpConnection>(self->context_, std::move(sock));
+          auto conn = std::make_shared<TcpConnection>(
+              self->context_, self->layers_, std::move(sock));
 
           auto session = std::make_shared<UpgraderSession>(
               self->upgrader_, self->layers_, std::move(conn), self->handle_);

--- a/src/transport/tcp/tcp_transport.cpp
+++ b/src/transport/tcp/tcp_transport.cpp
@@ -29,11 +29,11 @@ namespace libp2p::transport {
       return handler(std::errc::address_family_not_supported);
     }
 
-    auto conn = std::make_shared<TcpConnection>(*context_);
-
     auto [host, port] = detail::getHostAndTcpPort(address);
 
     auto layers = detail::getLayers(address);
+
+    auto conn = std::make_shared<TcpConnection>(*context_, layers);
 
     auto connect = [=,
                     self{shared_from_this()},


### PR DESCRIPTION
- fix wrong observed address caused by missing `"/ws"` `"/wss"` in `TcpConnection::remoteMultiaddr()`.
  - pass layers to `TcpConnection` constructor.
- fix yamux use-after-free ub.
  - (#226) `std::function` or boost asio handler didn't move `Bytes`, so `BytesIn` referenced first `Bytes` which were destroyed after copying.
  - callback captures `shared_ptr<Bytes> YamuxedConnection::writing_buf_` to keep `BytesIn` reference valid.