### PR TITLE
tsan weak_from_this race

### DIFF
--- a/include/libp2p/protocol/kademlia/impl/content_routing_table.hpp
+++ b/include/libp2p/protocol/kademlia/impl/content_routing_table.hpp
@@ -28,6 +28,8 @@ namespace libp2p::protocol::kademlia {
   struct ContentRoutingTable {
     virtual ~ContentRoutingTable() = default;
 
+    virtual void start() = 0;
+
     virtual void addProvider(const ContentId &key,
                              const peer::PeerId &peer) = 0;
 

--- a/include/libp2p/protocol/kademlia/impl/content_routing_table_impl.hpp
+++ b/include/libp2p/protocol/kademlia/impl/content_routing_table_impl.hpp
@@ -57,6 +57,8 @@ namespace libp2p::protocol::kademlia {
 
     ~ContentRoutingTableImpl() override;
 
+    void start() override;
+
     std::vector<PeerId> getProvidersFor(const ContentId &key,
                                         size_t limit = 0) const override;
 

--- a/src/protocol/kademlia/impl/content_routing_table_impl.cpp
+++ b/src/protocol/kademlia/impl/content_routing_table_impl.cpp
@@ -19,9 +19,10 @@ namespace libp2p::protocol::kademlia {
       : config_(config), scheduler_(scheduler), bus_(std::move(bus)) {
     BOOST_ASSERT(bus_ != nullptr);
     table_ = std::make_unique<Table>();
+  }
 
-    cleanup_timer_ =
-        scheduler_.scheduleWithHandle([this] { setTimerCleanup(); });
+  void ContentRoutingTableImpl::start() {
+    setTimerCleanup();
   }
 
   ContentRoutingTableImpl::~ContentRoutingTableImpl() = default;

--- a/src/protocol/kademlia/impl/kademlia_impl.cpp
+++ b/src/protocol/kademlia/impl/kademlia_impl.cpp
@@ -64,6 +64,8 @@ namespace libp2p::protocol::kademlia {
     }
     started_ = true;
 
+    content_routing_table_->start();
+
     // save himself into peer repo
     addPeer(host_->getPeerInfo(), true);
 


### PR DESCRIPTION
- kagome tsan application_injector_test
  - `ContentRoutingTableImpl` is called on init thread
  - `setTimerCleanup` requires `weak_from_this`, so `io_context.post` (`scheduleWithHandle`) to libp2p thread
  - libp2p thread is faster than init thread
  - `setTimerCleanup` is called, calls `weak_from_this`
  - but init thread is still inside `make_shared` and didn't initialize `enable_shared_from_this`
- `ContentRoutingTableImpl::start` is called by `KademliaImpl::start` (so user doesn't need to call it)