### PR TITLE
Corrected Hunter link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Libp2p is a modular networking stack described in [spec](https://github.com/libp
 
 ## Dependencies
 
-All dependencies are managed using [Hunter](https://github.com/cpp-pm/hunter). It uses cmake to download required libraries and does not require downloading and installing packages manually.
+All dependencies are managed using [Hunter](https://github.com/qdrvm/hunter). It uses cmake to download required libraries and does not require downloading and installing packages manually.
 Target C++ compilers are:
 * GCC 7.4
 * Clang 6.0.1

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Libp2p is a modular networking stack described in [spec](https://github.com/libp
 
 ## Dependencies
 
-All dependencies are managed using [Hunter](hunter.sh). It uses cmake to download required libraries and does not require downloading and installing packages manually.
+All dependencies are managed using [Hunter](https://github.com/cpp-pm/hunter). It uses cmake to download required libraries and does not require downloading and installing packages manually.
 Target C++ compilers are:
 * GCC 7.4
 * Clang 6.0.1


### PR DESCRIPTION
Changed `hunter.sh` which doesn't exist in the project structure and when typed into the browser is a hijacked domain. It now points to the github page for the Hunter project specifically used in the build workflow. PRs goal is to resolve #250 