### PR TITLE
Remove noexcept from p2p

### DIFF
--- a/include/libp2p/basic/scheduler.hpp
+++ b/include/libp2p/basic/scheduler.hpp
@@ -40,7 +40,7 @@ namespace libp2p::basic {
      * Defers callback to be executed during the next IO loop cycle
      * @param cb callback
      */
-    void schedule(Callback &&cb) noexcept {
+    void schedule(Callback &&cb) {
       std::ignore = scheduleImpl(std::move(cb), Time::zero(), false);
     }
 
@@ -49,8 +49,7 @@ namespace libp2p::basic {
      * @param cb callback
      * @param delay_from_now time interval
      */
-    void schedule(Callback &&cb,
-                  std::chrono::milliseconds delay_from_now) noexcept {
+    void schedule(Callback &&cb, std::chrono::milliseconds delay_from_now) {
       std::ignore = scheduleImpl(std::move(cb), delay_from_now, false);
     }
 
@@ -60,7 +59,7 @@ namespace libp2p::basic {
      * @return handle which can be used for cancelling, rescheduling, and scoped
      * lifetime
      */
-    [[nodiscard]] Handle scheduleWithHandle(Callback &&cb) noexcept {
+    [[nodiscard]] Handle scheduleWithHandle(Callback &&cb) {
       return scheduleImpl(std::move(cb), Time::zero(), true);
     }
 
@@ -72,7 +71,7 @@ namespace libp2p::basic {
      * lifetime
      */
     [[nodiscard]] Handle scheduleWithHandle(
-        Callback &&cb, std::chrono::milliseconds delay_from_now) noexcept {
+        Callback &&cb, std::chrono::milliseconds delay_from_now) {
       return scheduleImpl(std::move(cb), delay_from_now, true);
     }
 
@@ -80,7 +79,7 @@ namespace libp2p::basic {
      * Backend's async
      * @return milliseconds since async's epoch
      */
-    virtual std::chrono::milliseconds now() const noexcept = 0;
+    virtual std::chrono::milliseconds now() const = 0;
 
     /**
      * Doesn't allow lvalue callbacks
@@ -99,6 +98,6 @@ namespace libp2p::basic {
      */
     virtual Handle scheduleImpl(Callback &&cb,
                                 std::chrono::milliseconds delay_from_now,
-                                bool make_handle) noexcept = 0;
+                                bool make_handle) = 0;
   };
 }  // namespace libp2p::basic

--- a/include/libp2p/basic/scheduler/asio_scheduler_backend.hpp
+++ b/include/libp2p/basic/scheduler/asio_scheduler_backend.hpp
@@ -32,7 +32,7 @@ namespace libp2p::basic {
     /**
      * @return Milliseconds since steady clock's epoch
      */
-    std::chrono::milliseconds now() const noexcept override;
+    std::chrono::milliseconds now() const override;
 
     /**
      * Sets the timer. Called by Scheduler implementation

--- a/include/libp2p/basic/scheduler/backend.hpp
+++ b/include/libp2p/basic/scheduler/backend.hpp
@@ -21,7 +21,7 @@ namespace libp2p::basic {
     /**
      * Called from backend to fire callbacks
      */
-    virtual void pulse() noexcept = 0;
+    virtual void pulse() = 0;
   };
 
   /**
@@ -44,7 +44,7 @@ namespace libp2p::basic {
      * Current async
      * @return Milliseconds elapsed from async's epoch
      */
-    virtual std::chrono::milliseconds now() const noexcept = 0;
+    virtual std::chrono::milliseconds now() const = 0;
 
     /**
      * Implementation-defined defer or delay function.

--- a/include/libp2p/basic/scheduler/manual_scheduler_backend.hpp
+++ b/include/libp2p/basic/scheduler/manual_scheduler_backend.hpp
@@ -28,7 +28,7 @@ namespace libp2p::basic {
     /**
      * @return Milliseconds since clock's epoch. Clock is set manually
      */
-    std::chrono::milliseconds now() const noexcept override {
+    std::chrono::milliseconds now() const override {
       return current_clock_;
     }
 

--- a/include/libp2p/basic/scheduler/scheduler_impl.hpp
+++ b/include/libp2p/basic/scheduler/scheduler_impl.hpp
@@ -28,15 +28,15 @@ namespace libp2p::basic {
                   Scheduler::Config config);
 
     /// Returns current async
-    std::chrono::milliseconds now() const noexcept override;
+    std::chrono::milliseconds now() const override;
 
     /// Scheduler API impl
     Handle scheduleImpl(Callback &&cb,
                         std::chrono::milliseconds delay_from_now,
-                        bool make_handle) noexcept override;
+                        bool make_handle) override;
 
     /// Timer callback, called from SchedulerBackend
-    void pulse() noexcept override;
+    void pulse() override;
 
    private:
     size_t callReady(Time now);

--- a/include/libp2p/connection/layer_connection.hpp
+++ b/include/libp2p/connection/layer_connection.hpp
@@ -30,7 +30,7 @@ namespace libp2p::connection {
 
     /// returns if this side is an initiator of this connection, or false if it
     /// was a server in that case
-    virtual bool isInitiator() const noexcept = 0;
+    virtual bool isInitiator() const = 0;
 
     /**
      * @brief Get local multiaddress for this connection.

--- a/include/libp2p/event/bus.hpp
+++ b/include/libp2p/event/bus.hpp
@@ -64,7 +64,7 @@ namespace libp2p::event {
      * Explicitly unsubscribe from channel before the lifetime
      * of this object expires
      */
-    void unsubscribe() noexcept {
+    void unsubscribe() {
       if (handle_.connected()) {
         try {
           handle_.disconnect();
@@ -78,7 +78,7 @@ namespace libp2p::event {
     Handle() = default;
 
     /// Cancels existing connection
-    Handle &operator=(Handle &&rhs) noexcept {
+    Handle &operator=(Handle &&rhs) {
       unsubscribe();
       handle_ = std::move(rhs.handle_);
 

--- a/include/libp2p/layer/websocket/ssl_connection.hpp
+++ b/include/libp2p/layer/websocket/ssl_connection.hpp
@@ -25,7 +25,7 @@ namespace libp2p::connection {
                   std::shared_ptr<LayerConnection> connection,
                   std::shared_ptr<boost::asio::ssl::context> ssl_context);
 
-    bool isInitiator() const noexcept override;
+    bool isInitiator() const override;
     outcome::result<multi::Multiaddress> localMultiaddr() override;
     outcome::result<multi::Multiaddress> remoteMultiaddr() override;
 

--- a/include/libp2p/layer/websocket/ws_connection.hpp
+++ b/include/libp2p/layer/websocket/ws_connection.hpp
@@ -55,7 +55,7 @@ namespace libp2p::connection {
                           std::shared_ptr<LayerConnection> connection,
                           std::shared_ptr<basic::Scheduler> scheduler);
 
-    bool isInitiator() const noexcept override;
+    bool isInitiator() const override;
 
     void start();
     void stop();

--- a/include/libp2p/multi/multihash.hpp
+++ b/include/libp2p/multi/multihash.hpp
@@ -23,8 +23,8 @@ namespace libp2p::multi {
    public:
     Multihash(const Multihash &other) = default;
     Multihash &operator=(const Multihash &other) = default;
-    Multihash(Multihash &&other) noexcept = default;
-    Multihash &operator=(Multihash &&other) noexcept = default;
+    Multihash(Multihash &&other) = default;
+    Multihash &operator=(Multihash &&other) = default;
     ~Multihash() = default;
 
     using Buffer = Bytes;

--- a/include/libp2p/muxer/mplex/mplex.hpp
+++ b/include/libp2p/muxer/mplex/mplex.hpp
@@ -14,7 +14,7 @@ namespace libp2p::muxer {
    public:
     explicit Mplex(MuxedConnectionConfig config);
 
-    peer::ProtocolName getProtocolId() const noexcept override;
+    peer::ProtocolName getProtocolId() const override;
 
     void muxConnection(std::shared_ptr<connection::SecureConnection> conn,
                        CapConnCallbackFunc cb) const override;

--- a/include/libp2p/muxer/mplex/mplex_stream.hpp
+++ b/include/libp2p/muxer/mplex/mplex_stream.hpp
@@ -61,13 +61,13 @@ namespace libp2p::connection {
 
     void deferWriteCallback(std::error_code ec, WriteCallbackFunc cb) override;
 
-    bool isClosed() const noexcept override;
+    bool isClosed() const override;
 
     void close(VoidResultHandlerFunc cb) override;
 
-    bool isClosedForRead() const noexcept override;
+    bool isClosedForRead() const override;
 
-    bool isClosedForWrite() const noexcept override;
+    bool isClosedForWrite() const override;
 
     void reset() override;
 

--- a/include/libp2p/muxer/mplex/mplexed_connection.hpp
+++ b/include/libp2p/muxer/mplex/mplexed_connection.hpp
@@ -32,8 +32,8 @@ namespace libp2p::connection {
 
     MplexedConnection(const MplexedConnection &other) = delete;
     MplexedConnection &operator=(const MplexedConnection &other) = delete;
-    MplexedConnection(MplexedConnection &&other) noexcept = delete;
-    MplexedConnection &operator=(MplexedConnection &&other) noexcept = delete;
+    MplexedConnection(MplexedConnection &&other) = delete;
+    MplexedConnection &operator=(MplexedConnection &&other) = delete;
     ~MplexedConnection() override = default;
 
     void start() override;
@@ -52,7 +52,7 @@ namespace libp2p::connection {
 
     outcome::result<crypto::PublicKey> remotePublicKey() const override;
 
-    bool isInitiator() const noexcept override;
+    bool isInitiator() const override;
 
     outcome::result<multi::Multiaddress> localMultiaddr() override;
 

--- a/include/libp2p/muxer/yamux/yamux.hpp
+++ b/include/libp2p/muxer/yamux/yamux.hpp
@@ -27,7 +27,7 @@ namespace libp2p::muxer {
           std::shared_ptr<basic::Scheduler> scheduler,
           std::shared_ptr<network::ConnectionManager> cmgr);
 
-    peer::ProtocolName getProtocolId() const noexcept override;
+    peer::ProtocolName getProtocolId() const override;
 
     void muxConnection(std::shared_ptr<connection::SecureConnection> conn,
                        CapConnCallbackFunc cb) const override;

--- a/include/libp2p/muxer/yamux/yamux_stream.hpp
+++ b/include/libp2p/muxer/yamux/yamux_stream.hpp
@@ -65,13 +65,13 @@ namespace libp2p::connection {
 
     void deferWriteCallback(std::error_code ec, WriteCallbackFunc cb) override;
 
-    bool isClosed() const noexcept override;
+    bool isClosed() const override;
 
     void close(VoidResultHandlerFunc cb) override;
 
-    bool isClosedForRead() const noexcept override;
+    bool isClosedForRead() const override;
 
-    bool isClosedForWrite() const noexcept override;
+    bool isClosedForWrite() const override;
 
     void reset() override;
 

--- a/include/libp2p/muxer/yamux/yamuxed_connection.hpp
+++ b/include/libp2p/muxer/yamux/yamuxed_connection.hpp
@@ -64,7 +64,7 @@ namespace libp2p::connection {
 
     outcome::result<crypto::PublicKey> remotePublicKey() const override;
 
-    bool isInitiator() const noexcept override;
+    bool isInitiator() const override;
 
     outcome::result<multi::Multiaddress> localMultiaddr() override;
 

--- a/include/libp2p/peer/peer_address.hpp
+++ b/include/libp2p/peer/peer_address.hpp
@@ -61,13 +61,13 @@ namespace libp2p::peer {
      * Get a PeerId in this address
      * @return peer id
      */
-    const PeerId &getId() const noexcept;
+    const PeerId &getId() const;
 
     /**
      * Get a Multiaddress in this address
      * @return multiaddress
      */
-    const multi::Multiaddress &getAddress() const noexcept;
+    const multi::Multiaddress &getAddress() const;
 
    private:
     /**

--- a/include/libp2p/peer/peer_id.hpp
+++ b/include/libp2p/peer/peer_id.hpp
@@ -22,8 +22,8 @@ namespace libp2p::peer {
    public:
     PeerId(const PeerId &other) = default;
     PeerId &operator=(const PeerId &other) = default;
-    PeerId(PeerId &&other) noexcept = default;
-    PeerId &operator=(PeerId &&other) noexcept = default;
+    PeerId(PeerId &&other) = default;
+    PeerId &operator=(PeerId &&other) = default;
     ~PeerId() = default;
 
     enum class FactoryError { SUCCESS = 0, SHA256_EXPECTED = 1 };

--- a/include/libp2p/peer/peer_info.hpp
+++ b/include/libp2p/peer/peer_info.hpp
@@ -26,13 +26,13 @@ namespace libp2p::peer {
     }
 
     struct EqualByPeerId {
-      bool operator()(const PeerInfo &lhs, const PeerInfo &rhs) const noexcept {
+      bool operator()(const PeerInfo &lhs, const PeerInfo &rhs) const {
         return lhs.id == rhs.id;
       }
     };
 
     struct CompareByPeerId {
-      bool operator()(const PeerInfo &lhs, const PeerInfo &rhs) const noexcept {
+      bool operator()(const PeerInfo &lhs, const PeerInfo &rhs) const {
         return lhs.id.toVector() < rhs.id.toVector();
       }
     };

--- a/include/libp2p/protocol/common/subscription.hpp
+++ b/include/libp2p/protocol/common/subscription.hpp
@@ -25,7 +25,7 @@ namespace libp2p::protocol {
     Subscription(Subscription &&) = default;
 
     Subscription();
-    Subscription &operator=(Subscription &&) noexcept;
+    Subscription &operator=(Subscription &&);
     Subscription(uint64_t ticket, std::weak_ptr<Source> source);
     ~Subscription();
 

--- a/include/libp2p/protocol/identify/identify_msg_processor.hpp
+++ b/include/libp2p/protocol/identify/identify_msg_processor.hpp
@@ -60,19 +60,19 @@ namespace libp2p::protocol {
      * Get a Host of this processor
      * @return Host
      */
-    Host &getHost() const noexcept;
+    Host &getHost() const;
 
     /**
      * Get a ConnectionManager of this processor
      * @return ConnectionManager
      */
-    network::ConnectionManager &getConnectionManager() const noexcept;
+    network::ConnectionManager &getConnectionManager() const;
 
     /**
      * Get an ObservedAddresses of this processor
      * @return ObservedAddresses
      */
-    const ObservedAddresses &getObservedAddresses() const noexcept;
+    const ObservedAddresses &getObservedAddresses() const;
 
    private:
     /**

--- a/include/libp2p/protocol/kademlia/impl/peer_id_with_distance.hpp
+++ b/include/libp2p/protocol/kademlia/impl/peer_id_with_distance.hpp
@@ -18,7 +18,7 @@ namespace libp2p::protocol::kademlia {
           distance_(NodeId(peer_id).distance(NodeId(std::forward<T>(target)))) {
     }
 
-    bool operator<(const PeerIdWithDistance &other) const noexcept {
+    bool operator<(const PeerIdWithDistance &other) const {
       return std::memcmp(
                  distance_.data(), other.distance_.data(), distance_.size())
            < 0;

--- a/include/libp2p/security/noise/noise_connection.hpp
+++ b/include/libp2p/security/noise/noise_connection.hpp
@@ -57,7 +57,7 @@ namespace libp2p::connection {
 
     void deferWriteCallback(std::error_code ec, WriteCallbackFunc cb) override;
 
-    bool isInitiator() const noexcept override;
+    bool isInitiator() const override;
 
     outcome::result<multi::Multiaddress> localMultiaddr() override;
 

--- a/include/libp2p/security/plaintext/plaintext_connection.hpp
+++ b/include/libp2p/security/plaintext/plaintext_connection.hpp
@@ -29,7 +29,7 @@ namespace libp2p::connection {
 
     outcome::result<crypto::PublicKey> remotePublicKey() const override;
 
-    bool isInitiator() const noexcept override;
+    bool isInitiator() const override;
 
     outcome::result<multi::Multiaddress> localMultiaddr() override;
 

--- a/include/libp2p/security/secio/secio_connection.hpp
+++ b/include/libp2p/security/secio/secio_connection.hpp
@@ -90,7 +90,7 @@ namespace libp2p::connection {
 
     outcome::result<crypto::PublicKey> remotePublicKey() const override;
 
-    bool isInitiator() const noexcept override;
+    bool isInitiator() const override;
 
     outcome::result<multi::Multiaddress> localMultiaddr() override;
 

--- a/include/libp2p/storage/sqlite.hpp
+++ b/include/libp2p/storage/sqlite.hpp
@@ -63,8 +63,7 @@ namespace libp2p::storage {
      * @return number of rows affected, -1 in case of error
      */
     template <typename... Args>
-    inline int execCommand(StatementHandle st_handle,
-                           const Args &...args) noexcept {
+    inline int execCommand(StatementHandle st_handle, const Args &...args) {
       try {
         auto &st = getStatement(st_handle);
         bindArgs(st, args...);
@@ -91,7 +90,7 @@ namespace libp2p::storage {
     template <typename Sink, typename... Args>
     inline bool execQuery(StatementHandle st_handle,
                           Sink &&sink,
-                          const Args &...args) noexcept {
+                          const Args &...args) {
       try {
         auto &st = getStatement(st_handle);
         bindArgs(st, args...);

--- a/include/libp2p/transport/tcp/tcp_connection.hpp
+++ b/include/libp2p/transport/tcp/tcp_connection.hpp
@@ -76,7 +76,7 @@ namespace libp2p::transport {
 
     outcome::result<multi::Multiaddress> localMultiaddr() override;
 
-    bool isInitiator() const noexcept override;
+    bool isInitiator() const override;
 
     outcome::result<void> close() override;
 

--- a/src/basic/scheduler/asio_scheduler_backend.cpp
+++ b/src/basic/scheduler/asio_scheduler_backend.cpp
@@ -18,7 +18,7 @@ namespace libp2p::basic {
     io_context_->post(std::move(cb));
   }
 
-  std::chrono::milliseconds AsioSchedulerBackend::now() const noexcept {
+  std::chrono::milliseconds AsioSchedulerBackend::now() const {
     return nowImpl();
   }
 

--- a/src/basic/scheduler/scheduler_impl.cpp
+++ b/src/basic/scheduler/scheduler_impl.cpp
@@ -12,14 +12,14 @@ namespace libp2p::basic {
                                Scheduler::Config config)
       : backend_{std::move(backend)}, config_{config} {}
 
-  std::chrono::milliseconds SchedulerImpl::now() const noexcept {
+  std::chrono::milliseconds SchedulerImpl::now() const {
     return backend_->now();
   }
 
   Scheduler::Handle SchedulerImpl::scheduleImpl(
       Callback &&cb,
       std::chrono::milliseconds delay_from_now,
-      bool make_handle) noexcept {
+      bool make_handle) {
     if (not cb) {
       throw std::logic_error{"SchedulerImpl::scheduleImpl empty cb arg"};
     }
@@ -84,7 +84,7 @@ namespace libp2p::basic {
         });
   }
 
-  void SchedulerImpl::pulse() noexcept {
+  void SchedulerImpl::pulse() {
     callReady(Time::zero());
     while (not callbacks_.empty()) {
       auto now = backend_->now();

--- a/src/layer/websocket/ssl_connection.cpp
+++ b/src/layer/websocket/ssl_connection.cpp
@@ -23,7 +23,7 @@ namespace libp2p::connection {
             *ssl_context_,
         } {}
 
-  bool SslConnection::isInitiator() const noexcept {
+  bool SslConnection::isInitiator() const {
     return connection_->isInitiator();
   }
 

--- a/src/layer/websocket/ws_connection.cpp
+++ b/src/layer/websocket/ws_connection.cpp
@@ -65,7 +65,7 @@ namespace libp2p::connection {
     SL_DEBUG(log_, "Received unexpected pong. Ignoring");
   }
 
-  bool WsConnection::isInitiator() const noexcept {
+  bool WsConnection::isInitiator() const {
     return connection_->isInitiator();
   }
 

--- a/src/multi/multibase_codec/codecs/base58.cpp
+++ b/src/multi/multibase_codec/codecs/base58.cpp
@@ -45,7 +45,7 @@ namespace {
    * @param c - char to be tested
    * @return true, if char is space, false otherwise
    */
-  constexpr bool isSpace(char c) noexcept {
+  constexpr bool isSpace(char c) {
     return c == ' ' || c == '\f' || c == '\n' || c == '\r' || c == '\t'
         || c == '\v';
   }

--- a/src/muxer/mplex/mplex.cpp
+++ b/src/muxer/mplex/mplex.cpp
@@ -13,7 +13,7 @@
 namespace libp2p::muxer {
   Mplex::Mplex(MuxedConnectionConfig config) : config_{config} {}
 
-  peer::ProtocolName Mplex::getProtocolId() const noexcept {
+  peer::ProtocolName Mplex::getProtocolId() const {
     return "/mplex/6.7.0";
   }
 

--- a/src/muxer/mplex/mplex_stream.cpp
+++ b/src/muxer/mplex/mplex_stream.cpp
@@ -154,7 +154,7 @@ namespace libp2p::connection {
     connection_.lock()->deferWriteCallback(ec, std::move(cb));
   }
 
-  bool MplexStream::isClosed() const noexcept {
+  bool MplexStream::isClosed() const {
     return isClosedForRead() && isClosedForWrite();
   }
 
@@ -177,11 +177,11 @@ namespace libp2p::connection {
         });
   }
 
-  bool MplexStream::isClosedForRead() const noexcept {
+  bool MplexStream::isClosedForRead() const {
     return !is_readable_;
   }
 
-  bool MplexStream::isClosedForWrite() const noexcept {
+  bool MplexStream::isClosedForWrite() const {
     return !is_writable_;
   }
 

--- a/src/muxer/mplex/mplexed_connection.cpp
+++ b/src/muxer/mplex/mplexed_connection.cpp
@@ -101,7 +101,7 @@ namespace libp2p::connection {
     return connection_->remotePublicKey();
   }
 
-  bool MplexedConnection::isInitiator() const noexcept {
+  bool MplexedConnection::isInitiator() const {
     return connection_->isInitiator();
   }
 

--- a/src/muxer/yamux/yamux.cpp
+++ b/src/muxer/yamux/yamux.cpp
@@ -28,7 +28,7 @@ namespace libp2p::muxer {
     }
   }
 
-  peer::ProtocolName Yamux::getProtocolId() const noexcept {
+  peer::ProtocolName Yamux::getProtocolId() const {
     return "/yamux/1.0.0";
   }
 

--- a/src/muxer/yamux/yamux_stream.cpp
+++ b/src/muxer/yamux/yamux_stream.cpp
@@ -85,7 +85,7 @@ namespace libp2p::connection {
     });
   }
 
-  bool YamuxStream::isClosed() const noexcept {
+  bool YamuxStream::isClosed() const {
     return close_reason_.has_value();
   }
 
@@ -128,11 +128,11 @@ namespace libp2p::connection {
     return p;
   }
 
-  bool YamuxStream::isClosedForRead() const noexcept {
+  bool YamuxStream::isClosedForRead() const {
     return !is_readable_;
   }
 
-  bool YamuxStream::isClosedForWrite() const noexcept {
+  bool YamuxStream::isClosedForWrite() const {
     return !is_writable_;
   }
 

--- a/src/muxer/yamux/yamuxed_connection.cpp
+++ b/src/muxer/yamux/yamuxed_connection.cpp
@@ -144,7 +144,7 @@ namespace libp2p::connection {
     return connection_->remotePublicKey();
   }
 
-  bool YamuxedConnection::isInitiator() const noexcept {
+  bool YamuxedConnection::isInitiator() const {
     return connection_->isInitiator();
   }
 

--- a/src/peer/peer_address.cpp
+++ b/src/peer/peer_address.cpp
@@ -67,11 +67,11 @@ namespace libp2p::peer {
          + id_.toBase58();
   }
 
-  const PeerId &PeerAddress::getId() const noexcept {
+  const PeerId &PeerAddress::getId() const {
     return id_;
   }
 
-  const multi::Multiaddress &PeerAddress::getAddress() const noexcept {
+  const multi::Multiaddress &PeerAddress::getAddress() const {
     return address_;
   }
 }  // namespace libp2p::peer

--- a/src/protocol/common/subscription.cpp
+++ b/src/protocol/common/subscription.cpp
@@ -18,7 +18,7 @@ namespace libp2p::protocol {
     assert(source_wptr_.lock());
   }
 
-  Subscription &Subscription::operator=(Subscription &&x) noexcept {
+  Subscription &Subscription::operator=(Subscription &&x) {
     cancel();
     ticket_ = x.ticket_;
     source_wptr_ = std::move(x.source_wptr_);

--- a/src/protocol/identify/identify_msg_processor.cpp
+++ b/src/protocol/identify/identify_msg_processor.cpp
@@ -134,17 +134,17 @@ namespace libp2p::protocol {
         });
   }
 
-  Host &IdentifyMessageProcessor::getHost() const noexcept {
+  Host &IdentifyMessageProcessor::getHost() const {
     return host_;
   }
 
   network::ConnectionManager &IdentifyMessageProcessor::getConnectionManager()
-      const noexcept {
+      const {
     return conn_manager_;
   }
 
   const ObservedAddresses &IdentifyMessageProcessor::getObservedAddresses()
-      const noexcept {
+      const {
     return observed_addresses_;
   }
 

--- a/src/security/noise/noise_connection.cpp
+++ b/src/security/noise/noise_connection.cpp
@@ -152,7 +152,7 @@ namespace libp2p::connection {
     connection_->deferWriteCallback(ec, std::move(cb));
   }
 
-  bool NoiseConnection::isInitiator() const noexcept {
+  bool NoiseConnection::isInitiator() const {
     return connection_->isInitiator();
   }
 

--- a/src/security/plaintext/plaintext_connection.cpp
+++ b/src/security/plaintext/plaintext_connection.cpp
@@ -45,7 +45,7 @@ namespace libp2p::connection {
     return remote_;
   }
 
-  bool PlaintextConnection::isInitiator() const noexcept {
+  bool PlaintextConnection::isInitiator() const {
     return original_connection_->isInitiator();
   }
 

--- a/src/security/secio/secio_connection.cpp
+++ b/src/security/secio/secio_connection.cpp
@@ -165,7 +165,7 @@ namespace libp2p::connection {
     return remote_;
   }
 
-  bool SecioConnection::isInitiator() const noexcept {
+  bool SecioConnection::isInitiator() const {
     return original_connection_->isInitiator();
   }
 

--- a/src/security/tls/tls_connection.cpp
+++ b/src/security/tls/tls_connection.cpp
@@ -114,7 +114,7 @@ namespace libp2p::connection {
     return remote_pubkey_.value();
   }
 
-  bool TlsConnection::isInitiator() const noexcept {
+  bool TlsConnection::isInitiator() const {
     return original_connection_->isInitiator();
   }
 

--- a/src/security/tls/tls_connection.hpp
+++ b/src/security/tls/tls_connection.hpp
@@ -68,7 +68,7 @@ namespace libp2p::connection {
     outcome::result<crypto::PublicKey> remotePublicKey() const override;
 
     /// Returns true if connection is outbound
-    bool isInitiator() const noexcept override;
+    bool isInitiator() const override;
 
     /// Returns local network address
     outcome::result<multi::Multiaddress> localMultiaddr() override;

--- a/src/transport/tcp/tcp_connection.cpp
+++ b/src/transport/tcp/tcp_connection.cpp
@@ -83,7 +83,7 @@ namespace libp2p::transport {
     return local_multiaddress_.value();
   }
 
-  bool TcpConnection::isInitiator() const noexcept {
+  bool TcpConnection::isInitiator() const {
     return initiator_;
   }
 

--- a/test/libp2p/event/event_emitter_test.cpp
+++ b/test/libp2p/event/event_emitter_test.cpp
@@ -87,8 +87,8 @@ TEST_F(EventEmitterTest, NonCopyableEvent) {
     explicit NonCopyableEvent(int i) : value(i) {}
     NonCopyableEvent(const NonCopyableEvent &other) = delete;
     NonCopyableEvent &operator=(const NonCopyableEvent &other) = delete;
-    NonCopyableEvent(NonCopyableEvent &&other) noexcept = default;
-    NonCopyableEvent &operator=(NonCopyableEvent &&other) noexcept = default;
+    NonCopyableEvent(NonCopyableEvent &&other) = default;
+    NonCopyableEvent &operator=(NonCopyableEvent &&other) = default;
 
     int value;
   };
@@ -114,8 +114,8 @@ TEST_F(EventEmitterTest, NonMovableEvent) {
     explicit NonMovableEvent(int v) : value(v) {}
     NonMovableEvent(const NonMovableEvent &other) = default;
     NonMovableEvent &operator=(const NonMovableEvent &other) = default;
-    NonMovableEvent(NonMovableEvent &&other) noexcept = delete;
-    NonMovableEvent &operator=(NonMovableEvent &&other) noexcept = delete;
+    NonMovableEvent(NonMovableEvent &&other) = delete;
+    NonMovableEvent &operator=(NonMovableEvent &&other) = delete;
 
     int value;
   };
@@ -141,10 +141,9 @@ TEST_F(EventEmitterTest, NonCopyableOrMovableEvent) {
     NonCopyableOrMovableEvent(const NonCopyableOrMovableEvent &other) = delete;
     NonCopyableOrMovableEvent &operator=(
         const NonCopyableOrMovableEvent &other) = delete;
-    NonCopyableOrMovableEvent(NonCopyableOrMovableEvent &&other) noexcept =
+    NonCopyableOrMovableEvent(NonCopyableOrMovableEvent &&other) = delete;
+    NonCopyableOrMovableEvent &operator=(NonCopyableOrMovableEvent &&other) =
         delete;
-    NonCopyableOrMovableEvent &operator=(
-        NonCopyableOrMovableEvent &&other) noexcept = delete;
 
     int value;
   };

--- a/test/mock/libp2p/basic/scheduler_mock.hpp
+++ b/test/mock/libp2p/basic/scheduler_mock.hpp
@@ -13,15 +13,12 @@
 namespace libp2p::basic {
 
   struct SchedulerMock : public Scheduler {
-    MOCK_METHOD(std::chrono::milliseconds,
-                now,
-                (),
-                (const, noexcept, override));
+    MOCK_METHOD(std::chrono::milliseconds, now, (), (const, override));
 
     MOCK_METHOD(Cancel,
                 scheduleImpl,
                 (Callback &&, std::chrono::milliseconds, bool),
-                (noexcept, override));
+                (override));
   };
 
 }  // namespace libp2p::basic

--- a/test/mock/libp2p/connection/capable_connection_mock.hpp
+++ b/test/mock/libp2p/connection/capable_connection_mock.hpp
@@ -38,7 +38,7 @@ namespace libp2p::connection {
                  void(outcome::result<size_t>, Reader::ReadCallbackFunc));
     MOCK_METHOD2(deferWriteCallback,
                  void(std::error_code, Writer::WriteCallbackFunc));
-    bool isInitiator() const noexcept override {
+    bool isInitiator() const override {
       return true;  // TODO(artem): fix reuse connections in opposite direction
       // return isInitiator_hack();
     }
@@ -69,7 +69,7 @@ namespace libp2p::connection {
 
     MOCK_CONST_METHOD0(remotePublicKey, outcome::result<crypto::PublicKey>());
 
-    bool isInitiator() const noexcept override {
+    bool isInitiator() const override {
       return real_->isInitiator();
     }
 

--- a/test/mock/libp2p/connection/layer_connection_mock.hpp
+++ b/test/mock/libp2p/connection/layer_connection_mock.hpp
@@ -28,7 +28,7 @@ namespace libp2p::connection {
     MOCK_METHOD2(deferWriteCallback,
                  void(std::error_code, Writer::WriteCallbackFunc));
 
-    bool isInitiator() const noexcept override {
+    bool isInitiator() const override {
       return isInitiator_hack();
     }
 

--- a/test/mock/libp2p/connection/secure_connection_mock.hpp
+++ b/test/mock/libp2p/connection/secure_connection_mock.hpp
@@ -29,7 +29,7 @@ namespace libp2p::connection {
                  void(std::error_code, Writer::WriteCallbackFunc));
 
     MOCK_CONST_METHOD0(isInitiator_hack, bool(void));
-    bool isInitiator() const noexcept override {
+    bool isInitiator() const override {
       return isInitiator_hack();
     }
 


### PR DESCRIPTION
Allows to see actual stack traces in case of crashes.

Reconsidered as premature optimization.