### PR TITLE
fix kad quorum

### DIFF
--- a/include/libp2p/protocol/kademlia/impl/get_value_executor.hpp
+++ b/include/libp2p/protocol/kademlia/impl/get_value_executor.hpp
@@ -67,6 +67,8 @@ namespace libp2p::protocol::kademlia {
     /// Handles result of connection
     void onConnected(StreamAndProtocolOrError stream_res);
 
+    void finish();
+
     static std::atomic_size_t instance_number;
 
     // Primary


### PR DESCRIPTION
- insufficient quorum is not an error
  ```
  polkadot-sdk/substrate/client/network/src/discovery.rs:
       96: // The minimum number of peers we expect an answer before we terminate the request.
       97: const GET_RECORD_REDUNDANCY_FACTOR: u32 = 4;
      889:     Ok(GetRecordOk::FoundRecord(r)) => {
      899:       // Let's directly finish the query if we are above 4.
      905:       if stats.num_successes() > GET_RECORD_REDUNDANCY_FACTOR {
      908:         query.finish();
      917:       DiscoveryOut::ValueFound(r, stats.duration().unwrap_or_default())
      919:     Ok(GetRecordOk::FinishedWithNoAdditionalRecord {
  ```