### PR TITLE
fix asan

### DIFF
--- a/src/security/tls/tls_details.cpp
+++ b/src/security/tls/tls_details.cpp
@@ -208,10 +208,10 @@ namespace libp2p::security::tls_details {
       }
 
       ASN1_INTEGER *rand_int = ASN1_INTEGER_new();
+      CLEANUP_PTR(rand_int, ASN1_INTEGER_free);
       BN_to_ASN1_INTEGER(bn, rand_int);
 
       if (X509_set_serialNumber(cert, rand_int) == 0) {
-        ASN1_INTEGER_free(rand_int);
         throw std::runtime_error("cannot add SN to certificate");
       }
     }


### PR DESCRIPTION
- `X509_set_serialNumber` argument isn't moved, but copied
  https://github.com/qdrvm/boringssl/blob/f8065eabdb6695251467b4236161f5c63fc0be55/crypto/x509/x509_set.c#L100-L119