### PR TITLE
fix kad double read

### DIFF
--- a/include/libp2p/protocol/kademlia/impl/kademlia_impl.hpp
+++ b/include/libp2p/protocol/kademlia/impl/kademlia_impl.hpp
@@ -84,9 +84,6 @@ namespace libp2p::protocol::kademlia {
     std::shared_ptr<Session> openSession(
         std::shared_ptr<connection::Stream> stream) override;
 
-    /// @see SessionHost::closeSession
-    void closeSession(std::shared_ptr<connection::Stream> stream) override;
-
    private:
     void onPutValue(const std::shared_ptr<Session> &session, Message &&msg);
     void onGetValue(const std::shared_ptr<Session> &session, Message &&msg);
@@ -141,26 +138,6 @@ namespace libp2p::protocol::kademlia {
     // Subscribtion to new connections
     event::Handle new_connection_subscription_;
     event::Handle on_disconnected_;
-
-    struct StreamPtrComparator {
-      bool operator()(const std::shared_ptr<connection::Stream> &lhs,
-                      const std::shared_ptr<connection::Stream> &rhs) const {
-        return lhs.get() == rhs.get();
-      }
-    };
-
-    struct StreamPtrHaher {
-      size_t operator()(const std::shared_ptr<connection::Stream> &s) const {
-        auto r = std::hash<decltype(s.get())>()(s.get());
-        return r;
-      }
-    };
-
-    std::unordered_map<const std::shared_ptr<connection::Stream>,
-                       std::shared_ptr<Session>,
-                       StreamPtrHaher,
-                       StreamPtrComparator>
-        sessions_;
 
     // Random walk's auxiliary data
     struct {

--- a/include/libp2p/protocol/kademlia/impl/session.hpp
+++ b/include/libp2p/protocol/kademlia/impl/session.hpp
@@ -6,85 +6,54 @@
 
 #pragma once
 
+#include <atomic>
 #include <functional>
 
-#include <libp2p/basic/scheduler.hpp>
-#include <libp2p/connection/stream.hpp>
-#include <libp2p/log/sublogger.hpp>
-#include <libp2p/multi/uvarint.hpp>
-#include <libp2p/protocol/kademlia/error.hpp>
-#include <libp2p/protocol/kademlia/impl/response_handler.hpp>
-#include <libp2p/protocol/kademlia/impl/session_host.hpp>
+#include <libp2p/protocol/kademlia/message.hpp>
+
+namespace libp2p::basic {
+  class MessageReadWriterUvarint;
+  class Scheduler;
+}  // namespace libp2p::basic
 
 namespace libp2p::protocol::kademlia {
+  class ResponseHandler;
+  class SessionHost;
+}  // namespace libp2p::protocol::kademlia
 
-  class FindPeerExecutor;
-
+namespace libp2p::protocol::kademlia {
   class Session : public std::enable_shared_from_this<Session> {
    public:
-    Session(std::weak_ptr<SessionHost> session_host,
-            std::weak_ptr<basic::Scheduler> scheduler,
+    Session(std::weak_ptr<basic::Scheduler> scheduler,
             std::shared_ptr<connection::Stream> stream,
-            Time operations_timeout = Time::zero());
-
+            Time operations_timeout);
     ~Session();
+
+    using OnRead = std::function<void(outcome::result<Message>)>;
+    void read(OnRead on_read);
+    using OnWrite = std::function<void(outcome::result<void>)>;
+    void write(BytesIn frame, OnWrite on_write);
+
+    void read(std::weak_ptr<SessionHost> weak_session_host);
+    void read(std::shared_ptr<ResponseHandler> response_handler);
+    void write(const Message &msg,
+               std::weak_ptr<SessionHost> weak_session_host);
+    void write(BytesIn frame,
+               std::shared_ptr<ResponseHandler> response_handler);
+    void write(BytesIn frame);
 
     std::shared_ptr<connection::Stream> stream() const {
       return stream_;
     }
 
-    boost::optional<Message::Type> expectedResponseType() const {
-      return expected_response_type_;
-    }
-
-    bool read();
-
-    bool write(const std::shared_ptr<std::vector<uint8_t>> &buffer,
-               const std::shared_ptr<ResponseHandler> &response_handler);
-
-    bool canBeClosed() const {
-      return not closed_ && writing_ == 0 && reading_ == 0;
-    }
-
-    void close(outcome::result<void> = outcome::success());
-
    private:
-    void onLengthRead(outcome::result<multi::UVarint> varint);
+    void setTimer();
 
-    void onMessageRead(outcome::result<size_t> res);
-
-    void onMessageWritten(
-        outcome::result<size_t> res,
-        const std::shared_ptr<ResponseHandler> &response_handler);
-
-    void setReadingTimeout();
-    void cancelReadingTimeout();
-
-    void setResponseTimeout(
-        const std::shared_ptr<ResponseHandler> &response_handler);
-    void cancelResponseTimeout(
-        const std::shared_ptr<ResponseHandler> &response_handler);
-
-    std::unordered_map<std::shared_ptr<ResponseHandler>,
-                       basic::Scheduler::Handle>
-        response_handlers_;
-
-    std::weak_ptr<SessionHost> session_host_;
     std::weak_ptr<basic::Scheduler> scheduler_;
     std::shared_ptr<connection::Stream> stream_;
-
-    std::vector<uint8_t> inner_buffer_;
-
-    std::atomic_size_t reading_ = 0;
-    std::atomic_size_t writing_ = 0;
-    bool closed_ = false;
-
     const Time operations_timeout_;
-    basic::Scheduler::Handle reading_timeout_handle_;
 
-    boost::optional<Message::Type> expected_response_type_;
-
-    static std::atomic_size_t instance_number;
-    log::SubLogger log_;
+    std::shared_ptr<basic::MessageReadWriterUvarint> framing_;
+    Cancel timer_;
   };
 }  // namespace libp2p::protocol::kademlia

--- a/include/libp2p/protocol/kademlia/impl/session_host.hpp
+++ b/include/libp2p/protocol/kademlia/impl/session_host.hpp
@@ -19,9 +19,6 @@ namespace libp2p::protocol::kademlia {
     /// Opens new session for stream
     virtual std::shared_ptr<Session> openSession(
         std::shared_ptr<connection::Stream> stream) = 0;
-
-    /// Closes session by stream
-    virtual void closeSession(std::shared_ptr<connection::Stream> stream) = 0;
   };
 
 }  // namespace libp2p::protocol::kademlia

--- a/include/libp2p/protocol/kademlia/message.hpp
+++ b/include/libp2p/protocol/kademlia/message.hpp
@@ -51,7 +51,7 @@ namespace libp2p::protocol::kademlia {
     void clear();
 
     // tries to deserialize message from byte array
-    bool deserialize(const void *data, size_t sz);
+    bool deserialize(BytesIn pb);
 
     // serializes varint(message length) + message into buffer
     bool serialize(std::vector<uint8_t> &buffer) const;

--- a/src/protocol/kademlia/impl/find_peer_executor.cpp
+++ b/src/protocol/kademlia/impl/find_peer_executor.cpp
@@ -198,17 +198,7 @@ namespace libp2p::protocol::kademlia {
                stream->remotePeerId().value().toBase58());
 
     auto session = session_host_->openSession(stream);
-    if (!session->write(serialized_request_, shared_from_this())) {
-      --requests_in_progress_;
-
-      log_.debug("write to {} failed; active {}, in queue {}",
-                 addr,
-                 requests_in_progress_,
-                 queue_.size());
-
-      spawn();
-      return;
-    }
+    session->write(*serialized_request_, shared_from_this());
   }
 
   Time FindPeerExecutor::responseTimeout() const {

--- a/src/protocol/kademlia/impl/find_providers_executor.cpp
+++ b/src/protocol/kademlia/impl/find_providers_executor.cpp
@@ -212,18 +212,7 @@ namespace libp2p::protocol::kademlia {
                stream->remotePeerId().value().toBase58());
 
     auto session = session_host_->openSession(stream);
-
-    if (!session->write(serialized_request_, shared_from_this())) {
-      --requests_in_progress_;
-
-      log_.debug("write to {} failed; active {}, in queue {}",
-                 addr,
-                 requests_in_progress_,
-                 queue_.size());
-
-      spawn();
-      return;
-    }
+    session->write(*serialized_request_, shared_from_this());
   }
 
   Time FindProvidersExecutor::responseTimeout() const {

--- a/src/protocol/kademlia/impl/get_value_executor.cpp
+++ b/src/protocol/kademlia/impl/get_value_executor.cpp
@@ -205,18 +205,7 @@ namespace libp2p::protocol::kademlia {
                stream->remotePeerId().value().toBase58());
 
     auto session = session_host_->openSession(stream);
-
-    if (!session->write(serialized_request_, shared_from_this())) {
-      --requests_in_progress_;
-
-      log_.debug("write to {} failed; active {}, in queue {}",
-                 addr,
-                 requests_in_progress_,
-                 queue_.size());
-
-      spawn();
-      return;
-    }
+    session->write(*serialized_request_, shared_from_this());
   }
 
   Time GetValueExecutor::responseTimeout() const {

--- a/src/protocol/kademlia/impl/put_value_executor.cpp
+++ b/src/protocol/kademlia/impl/put_value_executor.cpp
@@ -140,16 +140,7 @@ namespace libp2p::protocol::kademlia {
                stream->remotePeerId().value().toBase58());
 
     auto session = session_host_->openSession(stream);
-
-    if (!session->write(serialized_request_, shared_from_this())) {
-      --requests_in_progress_;
-      log_.debug("write to {} failed; done {}, active {}, in queue {}",
-                 addr,
-                 requests_succeed_,
-                 requests_in_progress_,
-                 addressees_.size() - addressees_idx_);
-      spawn();
-    }
+    session->write(*serialized_request_, shared_from_this());
   }
 
   Time PutValueExecutor::responseTimeout() const {

--- a/src/protocol/kademlia/message.cpp
+++ b/src/protocol/kademlia/message.cpp
@@ -105,10 +105,10 @@ namespace libp2p::protocol::kademlia {
     error_message_.clear();
   }
 
-  bool Message::deserialize(const void *data, size_t sz) {
+  bool Message::deserialize(BytesIn pb) {
     clear();
     pb::Message pb_msg;
-    if (!pb_msg.ParseFromArray(data, static_cast<int>(sz))) {
+    if (!pb_msg.ParseFromArray(pb.data(), static_cast<int>(pb.size()))) {
       error_message_ = "Invalid protobuf data";
       return false;
     }


### PR DESCRIPTION
- `read` was called twice, from `onMessageRead` and `onMessageWritten`
- simplify and deduplicate read/write request/response
  - server (`SessionHost`) reads request, writes response, repeats.
  - client (`ResponseHandler`) writes request, reads response, closes stream.
    - `ADD_PROVIDER` writes request, (no response), closes stream.
- `read` uses `MessageReadWriterUvarint`, but `write` doesn't use that because `Message::serialize` adds length prefix. 