### PR TITLE
dial order

### DIFF
--- a/include/libp2p/host/basic_host/basic_host.hpp
+++ b/include/libp2p/host/basic_host/basic_host.hpp
@@ -48,8 +48,7 @@ namespace libp2p::host {
     Connectedness connectedness(const peer::PeerInfo &p) const override;
 
     void connect(const peer::PeerInfo &peer_info,
-                 const ConnectionResultHandler &handler,
-                 std::chrono::milliseconds timeout) override;
+                 const ConnectionResultHandler &handler) override;
 
     void disconnect(const peer::PeerId &peer_id) override;
 
@@ -57,12 +56,7 @@ namespace libp2p::host {
                             StreamAndProtocolCb cb,
                             ProtocolPredicate predicate) override;
 
-    void newStream(const peer::PeerInfo &peer_info,
-                   StreamProtocols protocols,
-                   StreamAndProtocolOrErrorCb cb,
-                   std::chrono::milliseconds timeout = {}) override;
-
-    void newStream(const peer::PeerId &peer_id,
+    void newStream(const PeerInfo &peer_id,
                    StreamProtocols protocols,
                    StreamAndProtocolOrErrorCb cb) override;
 

--- a/include/libp2p/host/host.hpp
+++ b/include/libp2p/host/host.hpp
@@ -125,21 +125,9 @@ namespace libp2p {
      * @brief Initiates connection to the peer {@param peer_info}.
      * @param peer_info peer to connect.
      * @param handler callback, will be executed on success or fail
-     * @param timeout in milliseconds
      */
     virtual void connect(const peer::PeerInfo &peer_info,
-                         const ConnectionResultHandler &handler,
-                         std::chrono::milliseconds timeout) = 0;
-
-    /**
-     * @brief Initiates connection to the peer {@param peer_info}.
-     * @param peer_info peer to connect.
-     * @param handler callback, will be executed on success or fail
-     */
-    inline void connect(const peer::PeerInfo &peer_info,
-                        const ConnectionResultHandler &handler) {
-      connect(peer_info, handler, std::chrono::milliseconds::zero());
-    };
+                         const ConnectionResultHandler &handler) = 0;
 
     /**
      * @brief Initiates connection to the peer {@param peer_info}. If connection
@@ -147,9 +135,8 @@ namespace libp2p {
      * @param peer_info peer to connect.
      */
     inline void connect(const peer::PeerInfo &peer_info) {
-      connect(
-          peer_info, [](auto &&) {}, std::chrono::milliseconds::zero());
-    };
+      connect(peer_info, [](ConnectionResult &&) {});
+    }
 
     /**
      * Closes all connections (outbound and inbound) to given {@param peer_id}
@@ -166,8 +153,7 @@ namespace libp2p {
      */
     virtual void newStream(const peer::PeerInfo &peer_info,
                            StreamProtocols protocols,
-                           StreamAndProtocolOrErrorCb cb,
-                           std::chrono::milliseconds timeout = {}) = 0;
+                           StreamAndProtocolOrErrorCb cb) = 0;
 
     /**
      * @brief Open new stream to the peer {@param peer} with protocol
@@ -176,9 +162,11 @@ namespace libp2p {
      * @param protocols "speak" using first supported protocol
      * @param cb callback, will be executed on success or fail
      */
-    virtual void newStream(const peer::PeerId &peer_id,
-                           StreamProtocols protocols,
-                           StreamAndProtocolOrErrorCb cb) = 0;
+    void newStream(const PeerId &peer_id,
+                   StreamProtocols protocols,
+                   StreamAndProtocolOrErrorCb cb) {
+      newStream(PeerInfo{.id = peer_id}, std::move(protocols), std::move(cb));
+    }
 
     /**
      * @brief Create listener on given multiaddress.

--- a/include/libp2p/host/host.hpp
+++ b/include/libp2p/host/host.hpp
@@ -145,11 +145,10 @@ namespace libp2p {
 
     /**
      * @brief Open new stream to the peer {@param peer_info} with protocol
-     * {@param protocol} with a specific timeout.
+     * {@param protocol}
      * @param peer_info stream will be opened to this peer
      * @param protocols "speak" using first supported protocol
      * @param cb callback, will be executed on success or fail
-     * @param timeout in milliseconds
      */
     virtual void newStream(const peer::PeerInfo &peer_info,
                            StreamProtocols protocols,

--- a/include/libp2p/injector/host_injector.hpp
+++ b/include/libp2p/injector/host_injector.hpp
@@ -10,7 +10,6 @@
 
 // implementations
 #include <libp2p/host/basic_host.hpp>
-#include <libp2p/peer/address_repository/inmem_address_repository.hpp>
 #include <libp2p/peer/impl/peer_repository_impl.hpp>
 #include <libp2p/peer/key_repository/inmem_key_repository.hpp>
 #include <libp2p/peer/protocol_repository/inmem_protocol_repository.hpp>
@@ -31,7 +30,6 @@ namespace libp2p::injector {
 
         // repositories
         di::bind<peer::PeerRepository>.to<peer::PeerRepositoryImpl>(),
-        di::bind<peer::AddressRepository>.to<peer::InmemAddressRepository>(),
         di::bind<peer::KeyRepository>.to<peer::InmemKeyRepository>(),
         di::bind<peer::ProtocolRepository>.to<peer::InmemProtocolRepository>(),
 

--- a/include/libp2p/injector/network_injector.hpp
+++ b/include/libp2p/injector/network_injector.hpp
@@ -31,6 +31,7 @@
 #include <libp2p/network/impl/network_impl.hpp>
 #include <libp2p/network/impl/router_impl.hpp>
 #include <libp2p/network/impl/transport_manager_impl.hpp>
+#include <libp2p/peer/address_repository/inmem_address_repository.hpp>
 #include <libp2p/peer/impl/identity_manager_impl.hpp>
 #include <libp2p/protocol_muxer/multiselect.hpp>
 #include <libp2p/security/noise.hpp>
@@ -346,6 +347,8 @@ namespace libp2p::injector {
         di::bind<security::SecurityAdaptor *[]>().to<security::Plaintext, security::Secio, security::Noise, security::TlsAdaptor>(),  // NOLINT
         di::bind<muxer::MuxerAdaptor *[]>().to<muxer::Yamux, muxer::Mplex>(),  // NOLINT
         di::bind<transport::TransportAdaptor *[]>().to<transport::TcpTransport, transport::QuicTransport>(),  // NOLINT
+
+        di::bind<peer::AddressRepository>.to<peer::InmemAddressRepository>(),
 
         // user-defined overrides...
         std::forward<decltype(args)>(args)...

--- a/include/libp2p/muxer/muxed_connection_config.hpp
+++ b/include/libp2p/muxer/muxed_connection_config.hpp
@@ -33,6 +33,7 @@ namespace libp2p::muxer {
         std::chrono::milliseconds(120000);
     std::chrono::milliseconds no_streams_interval = kDefaultNoStreamsInterval;
 
+    /// Dial timeout for outgoing connection
     static constexpr std::chrono::seconds kDefaultDialTimeout{10};
     std::chrono::milliseconds dial_timeout = kDefaultDialTimeout;
   };

--- a/include/libp2p/muxer/muxed_connection_config.hpp
+++ b/include/libp2p/muxer/muxed_connection_config.hpp
@@ -32,5 +32,8 @@ namespace libp2p::muxer {
     static constexpr std::chrono::milliseconds kDefaultNoStreamsInterval =
         std::chrono::milliseconds(120000);
     std::chrono::milliseconds no_streams_interval = kDefaultNoStreamsInterval;
+
+    static constexpr std::chrono::seconds kDefaultDialTimeout{10};
+    std::chrono::milliseconds dial_timeout = kDefaultDialTimeout;
   };
 }  // namespace libp2p::muxer

--- a/include/libp2p/network/dialer.hpp
+++ b/include/libp2p/network/dialer.hpp
@@ -32,33 +32,21 @@ namespace libp2p::network {
      * Establishes a connection or returns existing one to a given peer with a
      * specific timeout
      */
-    virtual void dial(const peer::PeerInfo &p,
-                      DialResultFunc cb,
-                      std::chrono::milliseconds timeout) = 0;
-
-    /**
-     * Establishes a connection or returns existing one to a given peer
-     */
-    inline void dial(const peer::PeerInfo &p, DialResultFunc cb) {
-      dial(p, std::move(cb), std::chrono::milliseconds::zero());
-    }
-
-    /**
-     * NewStream returns a new stream to given peer p with a specific timeout.
-     * If there is no connection to p, attempts to create one.
-     */
-    virtual void newStream(const peer::PeerInfo &peer_info,
-                           StreamProtocols protocols,
-                           StreamAndProtocolOrErrorCb cb,
-                           std::chrono::milliseconds timeout = {}) = 0;
+    virtual void dial(const PeerInfo &p, DialResultFunc cb) = 0;
 
     /**
      * NewStream returns a new stream to given peer p.
      * If there is no connection to p, returns error.
      */
-    virtual void newStream(const peer::PeerId &peer_id,
+    virtual void newStream(const PeerInfo &peer_id,
                            StreamProtocols protocols,
                            StreamAndProtocolOrErrorCb cb) = 0;
+
+    void newStream(const PeerId &peer_id,
+                   StreamProtocols protocols,
+                   StreamAndProtocolOrErrorCb cb) {
+      newStream(PeerInfo{.id = peer_id}, std::move(protocols), std::move(cb));
+    }
   };
 
 }  // namespace libp2p::network

--- a/include/libp2p/network/dialer.hpp
+++ b/include/libp2p/network/dialer.hpp
@@ -29,8 +29,7 @@ namespace libp2p::network {
     using DialResultFunc = std::function<void(DialResult)>;
 
     /**
-     * Establishes a connection or returns existing one to a given peer with a
-     * specific timeout
+     * Establishes a connection or returns existing one to a given peer
      */
     virtual void dial(const PeerInfo &p, DialResultFunc cb) = 0;
 

--- a/include/libp2p/network/impl/dialer_impl.hpp
+++ b/include/libp2p/network/impl/dialer_impl.hpp
@@ -30,18 +30,9 @@ namespace libp2p::network {
                std::shared_ptr<basic::Scheduler> scheduler);
 
     // Establishes a connection to a given peer
-    void dial(const peer::PeerInfo &p,
-              DialResultFunc cb,
-              std::chrono::milliseconds timeout) override;
+    void dial(const PeerInfo &p, DialResultFunc cb) override;
 
-    // NewStream returns a new stream to given peer p.
-    // If there is no connection to p, attempts to create one.
-    void newStream(const peer::PeerInfo &p,
-                   StreamProtocols protocols,
-                   StreamAndProtocolOrErrorCb cb,
-                   std::chrono::milliseconds timeout = {}) override;
-
-    void newStream(const peer::PeerId &peer_id,
+    void newStream(const PeerInfo &peer_id,
                    StreamProtocols protocols,
                    StreamAndProtocolOrErrorCb cb) override;
 
@@ -51,9 +42,6 @@ namespace libp2p::network {
     struct DialCtx {
       /// Known and scheduled addresses to try to dial via
       std::set<multi::Multiaddress> addresses;
-
-      /// Timeout for a single connection attempt
-      std::chrono::milliseconds timeout;
 
       /// Addresses we already tried, but no connection was established
       std::set<multi::Multiaddress> tried_addresses;

--- a/include/libp2p/network/impl/dialer_impl.hpp
+++ b/include/libp2p/network/impl/dialer_impl.hpp
@@ -43,7 +43,10 @@ namespace libp2p::network {
     // A context to handle an intermediary state of the peer we are dialing to
     // but the connection is not yet established
     struct DialCtx {
+      /// Queue of addresses to try connect to
       std::deque<Multiaddress> addr_queue;
+
+      /// Tracks addresses added to `addr_queue`
       std::unordered_set<Multiaddress> addr_seen;
 
       /// Callbacks for all who requested a connection to the peer

--- a/include/libp2p/network/impl/dialer_impl.hpp
+++ b/include/libp2p/network/impl/dialer_impl.hpp
@@ -6,14 +6,16 @@
 
 #pragma once
 
-#include <set>
+#include <deque>
 #include <unordered_map>
+#include <unordered_set>
 
 #include <libp2p/basic/scheduler.hpp>
 #include <libp2p/network/connection_manager.hpp>
 #include <libp2p/network/dialer.hpp>
 #include <libp2p/network/listener_manager.hpp>
 #include <libp2p/network/transport_manager.hpp>
+#include <libp2p/peer/address_repository.hpp>
 #include <libp2p/protocol_muxer/protocol_muxer.hpp>
 
 namespace libp2p::network {
@@ -27,6 +29,7 @@ namespace libp2p::network {
                std::shared_ptr<TransportManager> tmgr,
                std::shared_ptr<ConnectionManager> cmgr,
                std::shared_ptr<ListenerManager> listener,
+               std::shared_ptr<peer::AddressRepository> addr_repo,
                std::shared_ptr<basic::Scheduler> scheduler);
 
     // Establishes a connection to a given peer
@@ -40,11 +43,8 @@ namespace libp2p::network {
     // A context to handle an intermediary state of the peer we are dialing to
     // but the connection is not yet established
     struct DialCtx {
-      /// Known and scheduled addresses to try to dial via
-      std::set<multi::Multiaddress> addresses;
-
-      /// Addresses we already tried, but no connection was established
-      std::set<multi::Multiaddress> tried_addresses;
+      std::deque<Multiaddress> addr_queue;
+      std::unordered_set<Multiaddress> addr_seen;
 
       /// Callbacks for all who requested a connection to the peer
       std::vector<Dialer::DialResultFunc> callbacks;
@@ -74,6 +74,7 @@ namespace libp2p::network {
     std::shared_ptr<TransportManager> tmgr_;
     std::shared_ptr<ConnectionManager> cmgr_;
     std::shared_ptr<ListenerManager> listener_;
+    std::shared_ptr<peer::AddressRepository> addr_repo_;
     std::shared_ptr<basic::Scheduler> scheduler_;
     log::Logger log_;
 

--- a/include/libp2p/peer/address_repository.hpp
+++ b/include/libp2p/peer/address_repository.hpp
@@ -124,6 +124,13 @@ namespace libp2p::peer {
                                                   Milliseconds ttl) = 0;
 
     /**
+     * Move failed address to back.
+     * That way dialer will try other addresses first.
+     */
+    virtual void dialFailed(const PeerId &peer_id,
+                            const Multiaddress &addr) = 0;
+
+    /**
      * @brief Get all addresses associated with this Peer {@param p}. May
      * contain duplicates.
      * @param p peer

--- a/include/libp2p/peer/address_repository/inmem_address_repository.hpp
+++ b/include/libp2p/peer/address_repository/inmem_address_repository.hpp
@@ -50,6 +50,8 @@ namespace libp2p::peer {
     outcome::result<void> updateAddresses(const PeerId &p,
                                           Milliseconds ttl) override;
 
+    void dialFailed(const PeerId &peer_id, const Multiaddress &addr) override;
+
     outcome::result<std::vector<multi::Multiaddress>> getAddresses(
         const PeerId &p) const override;
 
@@ -60,13 +62,15 @@ namespace libp2p::peer {
     std::unordered_set<PeerId> getPeers() const override;
 
    private:
-    using ttlmap = std::unordered_map<multi::Multiaddress, Clock::time_point>;
-    using ttlmap_ptr = std::shared_ptr<ttlmap>;
-    using peer_db = std::unordered_map<PeerId, ttlmap_ptr>;
+    struct Peer {
+      std::unordered_map<Multiaddress, Clock::time_point> expires;
+      std::vector<Multiaddress> order;
+
+      bool eraseOrder(const Multiaddress &addr);
+    };
+    using peer_db = std::unordered_map<PeerId, Peer>;
 
     bool isNewDnsAddr(const multi::Multiaddress &ma);
-
-    peer_db::iterator findOrInsert(const PeerId &p);
 
     std::shared_ptr<network::DnsaddrResolver> dnsaddr_resolver_;
     peer_db db_;

--- a/include/libp2p/peer/peer_info.hpp
+++ b/include/libp2p/peer/peer_info.hpp
@@ -40,6 +40,10 @@ namespace libp2p::peer {
 
 }  // namespace libp2p::peer
 
+namespace libp2p {
+  using peer::PeerInfo;
+}  // namespace libp2p
+
 namespace std {
   template <>
   struct hash<libp2p::peer::PeerInfo> {

--- a/include/libp2p/transport/quic/transport.hpp
+++ b/include/libp2p/transport/quic/transport.hpp
@@ -50,8 +50,7 @@ namespace libp2p::transport {
     // TransportAdaptor
     void dial(const PeerId &peer,
               Multiaddress address,
-              TransportAdaptor::HandlerFunc cb,
-              std::chrono::milliseconds timeout) override;
+              TransportAdaptor::HandlerFunc cb) override;
     std::shared_ptr<TransportListener> createListener(
         TransportListener::HandlerFunc cb) override;
     bool canDial(const Multiaddress &ma) const override;

--- a/include/libp2p/transport/tcp/tcp_transport.hpp
+++ b/include/libp2p/transport/tcp/tcp_transport.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <boost/asio/ip/tcp.hpp>
+#include <libp2p/muxer/muxed_connection_config.hpp>
 #include <libp2p/transport/tcp/tcp_listener.hpp>
 #include <libp2p/transport/transport_adaptor.hpp>
 #include <libp2p/transport/upgrader.hpp>
@@ -22,16 +23,12 @@ namespace libp2p::transport {
     ~TcpTransport() override = default;
 
     TcpTransport(std::shared_ptr<boost::asio::io_context> context,
+                 const muxer::MuxedConnectionConfig &mux_config,
                  std::shared_ptr<Upgrader> upgrader);
 
     void dial(const peer::PeerId &remoteId,
               multi::Multiaddress address,
               TransportAdaptor::HandlerFunc handler) override;
-
-    void dial(const peer::PeerId &remoteId,
-              multi::Multiaddress address,
-              TransportAdaptor::HandlerFunc handler,
-              std::chrono::milliseconds timeout) override;
 
     std::shared_ptr<TransportListener> createListener(
         TransportListener::HandlerFunc handler) override;
@@ -42,6 +39,7 @@ namespace libp2p::transport {
 
    private:
     std::shared_ptr<boost::asio::io_context> context_;
+    muxer::MuxedConnectionConfig mux_config_;
     std::shared_ptr<Upgrader> upgrader_;
     boost::asio::ip::tcp::resolver resolver_;
   };

--- a/include/libp2p/transport/transport_adaptor.hpp
+++ b/include/libp2p/transport/transport_adaptor.hpp
@@ -40,25 +40,7 @@ namespace libp2p::transport {
      */
     virtual void dial(const peer::PeerId &remoteId,
                       multi::Multiaddress address,
-                      HandlerFunc handler) {
-      dial(remoteId,
-           std::move(address),
-           std::move(handler),
-           std::chrono::milliseconds(0));
-    }
-
-    /**
-     * Try to establish connection with a peer with specific timeout
-     * @param remoteId id of remote peer to dial
-     * @param address of the peer
-     * @param handler callback that will be executed on connection/error
-     * @param timeout in milliseconds for connection establishing
-     * @return connection in case of success, error otherwise
-     */
-    virtual void dial(const peer::PeerId &remoteId,
-                      multi::Multiaddress address,
-                      HandlerFunc handler,
-                      std::chrono::milliseconds timeout) = 0;
+                      HandlerFunc handler) = 0;
 
     /**
      * Create a listener for incoming connections of this Transport; in case

--- a/include/libp2p/transport/transport_adaptor.hpp
+++ b/include/libp2p/transport/transport_adaptor.hpp
@@ -32,7 +32,7 @@ namespace libp2p::transport {
     ~TransportAdaptor() override = default;
 
     /**
-     * Try to establish connection with a peer without timeout
+     * Try to establish connection with a peer
      * @param remoteId id of remote peer to dial
      * @param address of the peer
      * @param handler callback that will be executed on connection/error

--- a/src/host/basic_host/basic_host.cpp
+++ b/src/host/basic_host/basic_host.cpp
@@ -141,17 +141,9 @@ namespace libp2p::host {
 
   void BasicHost::newStream(const peer::PeerInfo &peer_info,
                             StreamProtocols protocols,
-                            StreamAndProtocolOrErrorCb cb,
-                            std::chrono::milliseconds timeout) {
-    network_->getDialer().newStream(
-        peer_info, std::move(protocols), std::move(cb), timeout);
-  }
-
-  void BasicHost::newStream(const peer::PeerId &peer_id,
-                            StreamProtocols protocols,
                             StreamAndProtocolOrErrorCb cb) {
     network_->getDialer().newStream(
-        peer_id, std::move(protocols), std::move(cb));
+        peer_info, std::move(protocols), std::move(cb));
   }
 
   outcome::result<void> BasicHost::listen(const multi::Multiaddress &ma) {
@@ -217,9 +209,8 @@ namespace libp2p::host {
   }
 
   void BasicHost::connect(const peer::PeerInfo &peer_info,
-                          const ConnectionResultHandler &handler,
-                          std::chrono::milliseconds timeout) {
-    network_->getDialer().dial(peer_info, handler, timeout);
+                          const ConnectionResultHandler &handler) {
+    network_->getDialer().dial(peer_info, handler);
   }
 
   void BasicHost::disconnect(const peer::PeerId &peer_id) {

--- a/src/protocol/gossip/impl/connectivity.cpp
+++ b/src/protocol/gossip/impl/connectivity.cpp
@@ -238,8 +238,7 @@ namespace libp2p::protocol::gossip {
           if (self) {
             onNewStream(ctx, std::move(rstream));
           }
-        },
-        config_.rw_timeout_msec
+        }
     );
     // clang-format on
   }

--- a/src/protocol/kademlia/impl/add_provider_executor.cpp
+++ b/src/protocol/kademlia/impl/add_provider_executor.cpp
@@ -143,16 +143,13 @@ namespace libp2p::protocol::kademlia {
           config_.connectionTimeout);
 
       host_->newStream(
-          peer_info,
-          config_.protocols,
-          [holder](auto &&stream_res) {
+          peer_info, config_.protocols, [holder](auto &&stream_res) {
             if (holder->first) {
               holder->second.reset();
               holder->first->onConnected(stream_res);
               holder->first.reset();
             }
-          },
-          config_.connectionTimeout);
+          });
     }
 
     if (requests_in_progress_ == 0) {

--- a/src/protocol/kademlia/impl/find_peer_executor.cpp
+++ b/src/protocol/kademlia/impl/find_peer_executor.cpp
@@ -154,16 +154,13 @@ namespace libp2p::protocol::kademlia {
           config_.connectionTimeout);
 
       host_->newStream(
-          peer_info,
-          config_.protocols,
-          [holder](auto &&stream_res) {
+          peer_info, config_.protocols, [holder](auto &&stream_res) {
             if (holder->first) {
               holder->second.reset();
               holder->first->onConnected(stream_res);
               holder->first.reset();
             }
-          },
-          config_.connectionTimeout);
+          });
     }
 
     if (requests_in_progress_ == 0) {

--- a/src/protocol/kademlia/impl/find_providers_executor.cpp
+++ b/src/protocol/kademlia/impl/find_providers_executor.cpp
@@ -168,16 +168,13 @@ namespace libp2p::protocol::kademlia {
           config_.connectionTimeout);
 
       host_->newStream(
-          peer_info,
-          config_.protocols,
-          [holder](auto &&stream_res) {
+          peer_info, config_.protocols, [holder](auto &&stream_res) {
             if (holder->first) {
               holder->second.reset();
               holder->first->onConnected(stream_res);
               holder->first.reset();
             }
-          },
-          config_.connectionTimeout);
+          });
     }
 
     if (requests_in_progress_ == 0) {

--- a/src/protocol/kademlia/impl/get_value_executor.cpp
+++ b/src/protocol/kademlia/impl/get_value_executor.cpp
@@ -151,16 +151,13 @@ namespace libp2p::protocol::kademlia {
           config_.connectionTimeout);
 
       host_->newStream(
-          peer_info,
-          config_.protocols,
-          [holder](auto &&stream_res) {
+          peer_info, config_.protocols, [holder](auto &&stream_res) {
             if (holder->first) {
               holder->second.reset();
               holder->first->onConnected(stream_res);
               holder->first.reset();
             }
-          },
-          config_.connectionTimeout);
+          });
     }
 
     if (done_) {

--- a/src/protocol/kademlia/impl/put_value_executor.cpp
+++ b/src/protocol/kademlia/impl/put_value_executor.cpp
@@ -95,16 +95,13 @@ namespace libp2p::protocol::kademlia {
           config_.connectionTimeout);
 
       host_->newStream(
-          peer_info,
-          config_.protocols,
-          [holder](auto &&stream_res) {
+          peer_info, config_.protocols, [holder](auto &&stream_res) {
             if (holder->first) {
               holder->second.reset();
               holder->first->onConnected(stream_res);
               holder->first.reset();
             }
-          },
-          config_.connectionTimeout);
+          });
     }
 
     if (requests_in_progress_ == 0) {

--- a/src/transport/quic/engine.cpp
+++ b/src/transport/quic/engine.cpp
@@ -53,6 +53,8 @@ namespace libp2p::transport::lsquic {
     settings.es_idle_timeout = std::chrono::duration_cast<std::chrono::seconds>(
                                    mux_config.no_streams_interval)
                                    .count();
+    settings.es_handshake_to =
+        std::chrono::microseconds{mux_config.dial_timeout}.count();
 
     static lsquic_stream_if stream_if{};
     stream_if.on_new_conn = +[](void *void_self, lsquic_conn_t *conn) {

--- a/src/transport/quic/transport.cpp
+++ b/src/transport/quic/transport.cpp
@@ -30,8 +30,7 @@ namespace libp2p::transport {
 
   void QuicTransport::dial(const PeerId &peer,
                            Multiaddress address,
-                           TransportAdaptor::HandlerFunc cb,
-                           std::chrono::milliseconds timeout) {
+                           TransportAdaptor::HandlerFunc cb) {
     auto r = detail::asQuic(address);
     if (not r) {
       return cb(r.error());

--- a/test/acceptance/p2p/host/basic_host_test.cpp
+++ b/test/acceptance/p2p/host/basic_host_test.cpp
@@ -136,7 +136,7 @@ TEST_F(BasicHostTest, GetAddressesInterfaces) {
 TEST_F(BasicHostTest, Connect) {
   peer::PeerInfo pinfo{"2"_peerid, {ma1}};
   EXPECT_CALL(network, getDialer()).WillOnce(ReturnRef(*dialer));
-  EXPECT_CALL(*dialer, dial(pinfo, _, _)).Times(1);
+  EXPECT_CALL(*dialer, dial(pinfo, _)).Times(1);
 
   host->connect(pinfo);
 }
@@ -151,11 +151,7 @@ TEST_F(BasicHostTest, NewStream) {
   peer::ProtocolName protocol = "/proto/1.0.0";
 
   EXPECT_CALL(network, getDialer()).WillOnce(ReturnRef(*dialer));
-  EXPECT_CALL(*dialer,
-              newStream(pinfo,
-                        StreamProtocols{protocol},
-                        _,
-                        std::chrono::milliseconds::zero()))
+  EXPECT_CALL(*dialer, newStream(pinfo, StreamProtocols{protocol}, _))
       .WillOnce(Arg2CallbackWithArg(StreamAndProtocol{stream, protocol}));
 
   bool executed = false;

--- a/test/acceptance/p2p/host/peer/test_peer.cpp
+++ b/test/acceptance/p2p/host/peer/test_peer.cpp
@@ -184,17 +184,17 @@ Peer::sptr<host::BasicHost> Peer::makeHost(const crypto::KeyPair &keyPair) {
   auto listener = std::make_shared<network::ListenerManagerImpl>(
       multiselect, std::move(router), tmgr, cmgr);
 
-  auto dialer = std::make_unique<network::DialerImpl>(
-      multiselect, tmgr, cmgr, listener, scheduler_);
-
-  auto network = std::make_unique<network::NetworkImpl>(
-      std::move(listener), std::move(dialer), cmgr);
-
   auto dnsaddr_resolver =
       std::make_shared<network::DnsaddrResolverImpl>(context_, cares_);
 
   auto addr_repo =
       std::make_shared<peer::InmemAddressRepository>(dnsaddr_resolver);
+
+  auto dialer = std::make_unique<network::DialerImpl>(
+      multiselect, tmgr, cmgr, listener, addr_repo, scheduler_);
+
+  auto network = std::make_unique<network::NetworkImpl>(
+      std::move(listener), std::move(dialer), cmgr);
 
   auto key_repo = std::make_shared<peer::InmemKeyRepository>();
 

--- a/test/acceptance/p2p/host/peer/test_peer.cpp
+++ b/test/acceptance/p2p/host/peer/test_peer.cpp
@@ -171,7 +171,8 @@ Peer::sptr<host::BasicHost> Peer::makeHost(const crypto::KeyPair &keyPair) {
                                                 std::move(muxer_adaptors));
 
   std::vector<std::shared_ptr<transport::TransportAdaptor>> transports = {
-      std::make_shared<transport::TcpTransport>(context_, std::move(upgrader))};
+      std::make_shared<transport::TcpTransport>(
+          context_, muxed_config_, std::move(upgrader))};
 
   auto tmgr =
       std::make_shared<network::TransportManagerImpl>(std::move(transports));

--- a/test/acceptance/p2p/muxer.cpp
+++ b/test/acceptance/p2p/muxer.cpp
@@ -47,6 +47,8 @@ using ::testing::Mock;
 using ::testing::NiceMock;
 using std::chrono_literals::operator""ms;
 
+muxer::MuxedConnectionConfig mux_config;
+
 static const size_t kServerBufSize = 10000;  // 10 Kb
 
 // allows to print debug output to stdout, not wanted in CI output, but
@@ -395,7 +397,8 @@ TEST_P(MuxerAcceptanceTest, ParallelEcho) {
   auto plaintext = std::make_shared<Plaintext>(
       msg_marshaller, idmgr, std::move(key_marshaller));
   auto upgrader = std::make_shared<UpgraderSemiMock>(plaintext, muxer);
-  auto transport = std::make_shared<TcpTransport>(server_context, upgrader);
+  auto transport =
+      std::make_shared<TcpTransport>(server_context, mux_config, upgrader);
   auto server = std::make_shared<Server>(transport);
   server->listen(serverAddr);
 
@@ -429,7 +432,8 @@ TEST_P(MuxerAcceptanceTest, ParallelEcho) {
         auto plaintext =
             std::make_shared<Plaintext>(msg_marshaller, idmgr, key_marshaller);
         auto upgrader = std::make_shared<UpgraderSemiMock>(plaintext, muxer);
-        auto transport = std::make_shared<TcpTransport>(context, upgrader);
+        auto transport =
+            std::make_shared<TcpTransport>(context, mux_config, upgrader);
         auto client = std::make_shared<Client>(
             transport, localSeed, context, streams, rounds);
 

--- a/test/libp2p/injector/CMakeLists.txt
+++ b/test/libp2p/injector/CMakeLists.txt
@@ -10,6 +10,7 @@ addtest(network_injector_test
 target_link_libraries(network_injector_test
     Boost::Boost.DI
     p2p_default_network
+    p2p_inmem_address_repository
     p2p_cares
     )
 

--- a/test/libp2p/network/dialer_test.cpp
+++ b/test/libp2p/network/dialer_test.cpp
@@ -96,16 +96,12 @@ TEST_F(DialerTest, DialAllTheAddresses) {
   EXPECT_CALL(*tmgr, findBest(ma2)).WillOnce(Return(transport));
 
   // transport->dial returns an error for the first address
-  EXPECT_CALL(
-      *transport,
-      dial(pinfo_two_addrs.id, ma1, _, std::chrono::milliseconds::zero()))
+  EXPECT_CALL(*transport, dial(pinfo_two_addrs.id, ma1, _))
       .WillOnce(
           Arg2CallbackWithArg(make_error_code(std::errc::connection_refused)));
 
   // transport->dial returns valid connection for the second address
-  EXPECT_CALL(
-      *transport,
-      dial(pinfo_two_addrs.id, ma2, _, std::chrono::milliseconds::zero()))
+  EXPECT_CALL(*transport, dial(pinfo_two_addrs.id, ma2, _))
       .WillOnce(Arg2CallbackWithArg(outcome::success(connection)));
 
   bool executed = false;
@@ -137,8 +133,7 @@ TEST_F(DialerTest, DialNewConnection) {
   EXPECT_CALL(*tmgr, findBest(ma1)).WillOnce(Return(transport));
 
   // transport->dial returns valid connection
-  EXPECT_CALL(*transport,
-              dial(pinfo.id, ma1, _, std::chrono::milliseconds::zero()))
+  EXPECT_CALL(*transport, dial(pinfo.id, ma1, _))
       .WillOnce(Arg2CallbackWithArg(outcome::success(connection)));
 
   bool executed = false;

--- a/test/libp2p/network/dialer_test.cpp
+++ b/test/libp2p/network/dialer_test.cpp
@@ -15,10 +15,13 @@
 #include "mock/libp2p/network/connection_manager_mock.hpp"
 #include "mock/libp2p/network/listener_mock.hpp"
 #include "mock/libp2p/network/transport_manager_mock.hpp"
+#include "mock/libp2p/peer/address_repository_mock.hpp"
 #include "mock/libp2p/protocol_muxer/protocol_muxer_mock.hpp"
 #include "mock/libp2p/transport/transport_mock.hpp"
 #include "testutil/gmock_actions.hpp"
 #include "testutil/prepare_loggers.hpp"
+
+using libp2p::peer::AddressRepositoryMock;
 
 using namespace libp2p;
 using namespace network;
@@ -40,7 +43,7 @@ struct DialerTest : public ::testing::Test {
   void SetUp() override {
     testutil::prepareLoggers();
     dialer = std::make_shared<DialerImpl>(
-        proto_muxer, tmgr, cmgr, listener, scheduler);
+        proto_muxer, tmgr, cmgr, listener, addr_repo, scheduler);
   }
 
   std::shared_ptr<StreamMock> stream = std::make_shared<StreamMock>();
@@ -60,6 +63,9 @@ struct DialerTest : public ::testing::Test {
       std::make_shared<ConnectionManagerMock>();
 
   std::shared_ptr<ListenerMock> listener = std::make_shared<ListenerMock>();
+
+  std::shared_ptr<AddressRepositoryMock> addr_repo =
+      std::make_shared<AddressRepositoryMock>();
 
   std::shared_ptr<ManualSchedulerBackend> scheduler_backend =
       std::make_shared<ManualSchedulerBackend>();

--- a/test/libp2p/protocol/identify_delta_test.cpp
+++ b/test/libp2p/protocol/identify_delta_test.cpp
@@ -122,9 +122,8 @@ TEST_F(IdentifyDeltaTest, Send) {
       .WillOnce(Return(kPeerInfo));
 
   // stream handling and message sending
-  EXPECT_CALL(
-      host_,
-      newStream(kPeerInfo, StreamProtocols{kIdentifyDeltaProtocol}, _, _))
+  EXPECT_CALL(host_,
+              newStream(kPeerInfo, StreamProtocols{kIdentifyDeltaProtocol}, _))
       .WillOnce(InvokeArgument<2>(
           StreamAndProtocol{stream_, kIdentifyDeltaProtocol}));
 

--- a/test/libp2p/protocol/identify_test.cpp
+++ b/test/libp2p/protocol/identify_test.cpp
@@ -82,7 +82,8 @@ class IdentifyTest : public testing::Test {
         host_, conn_manager_, id_manager_, key_marshaller_);
     IdentifyConfig config;
     config.protocols = {kIdentifyProto};
-    identify_ = std::make_shared<Identify>(config, host_, id_msg_processor_, bus_);
+    identify_ =
+        std::make_shared<Identify>(config, host_, id_msg_processor_, bus_);
   }
 
   HostMock host_;
@@ -211,7 +212,7 @@ TEST_F(IdentifyTest, Receive) {
       .WillOnce(Return(remote_multiaddr_));
 
   EXPECT_CALL(host_,
-              newStream(kRemotePeerInfo, StreamProtocols{kIdentifyProto}, _, _))
+              newStream(kRemotePeerInfo, StreamProtocols{kIdentifyProto}, _))
       .WillOnce(InvokeArgument<2>(StreamAndProtocol{stream_, kIdentifyProto}));
 
   EXPECT_CALL(*stream_, read(_, 1, _))

--- a/test/libp2p/protocol/ping_test.cpp
+++ b/test/libp2p/protocol/ping_test.cpp
@@ -130,7 +130,7 @@ TEST_F(PingTest, PingClient) {
   EXPECT_CALL(*conn_, remotePeer()).WillOnce(Return(peer_id_));
   EXPECT_CALL(host_, getPeerRepository()).WillOnce(ReturnRef(peer_repo_));
   EXPECT_CALL(peer_repo_, getPeerInfo(peer_id_)).WillOnce(Return(peer_info_));
-  EXPECT_CALL(host_, newStream(peer_info_, StreamProtocols{kPingProto}, _, _))
+  EXPECT_CALL(host_, newStream(peer_info_, StreamProtocols{kPingProto}, _))
       .WillOnce(InvokeArgument<2>(StreamAndProtocol{stream_, kPingProto}));
 
   EXPECT_CALL(*rand_gen_, randomBytes(kPingMsgSize))
@@ -172,7 +172,7 @@ TEST_F(PingTest, PingClientTimeoutExpired) {
   EXPECT_CALL(*conn_, remotePeer()).WillOnce(Return(peer_id_));
   EXPECT_CALL(host_, getPeerRepository()).WillOnce(ReturnRef(peer_repo_));
   EXPECT_CALL(peer_repo_, getPeerInfo(peer_id_)).WillOnce(Return(peer_info_));
-  EXPECT_CALL(host_, newStream(peer_info_, StreamProtocols{kPingProto}, _, _))
+  EXPECT_CALL(host_, newStream(peer_info_, StreamProtocols{kPingProto}, _))
       .WillOnce(InvokeArgument<2>(StreamAndProtocol{stream_, kPingProto}));
 
   EXPECT_CALL(*rand_gen_, randomBytes(kPingMsgSize)).WillOnce(Return(buffer_));

--- a/test/libp2p/transport/tcp/tcp_integration_test.cpp
+++ b/test/libp2p/transport/tcp/tcp_integration_test.cpp
@@ -33,6 +33,8 @@ using ::testing::Invoke;
 using ::testing::NiceMock;
 using ::testing::Return;
 
+libp2p::muxer::MuxedConnectionConfig mux_config;
+
 namespace {
   std::shared_ptr<CapableConnection> expectConnectionValid(
       outcome::result<std::shared_ptr<CapableConnection>> rconn) {
@@ -95,7 +97,8 @@ namespace {
 TEST(TCP, TwoListenersCantBindOnSamePort) {
   auto context = std::make_shared<boost::asio::io_context>(1);
   auto upgrader = makeUpgrader();
-  auto transport = std::make_shared<TcpTransport>(context, std::move(upgrader));
+  auto transport =
+      std::make_shared<TcpTransport>(context, mux_config, std::move(upgrader));
   auto listener1 = transport->createListener([](auto &&c) { EXPECT_TRUE(c); });
 
   ASSERT_TRUE(listener1);
@@ -129,7 +132,8 @@ TEST(TCP, SingleListenerCanAcceptManyClients) {
 
   auto context = std::make_shared<boost::asio::io_context>();
   auto upgrader = makeUpgrader();
-  auto transport = std::make_shared<TcpTransport>(context, std::move(upgrader));
+  auto transport =
+      std::make_shared<TcpTransport>(context, mux_config, std::move(upgrader));
   using libp2p::connection::RawConnection;
   auto listener = transport->createListener([&](auto &&rconn) {
     auto conn = expectConnectionValid(rconn);
@@ -160,8 +164,8 @@ TEST(TCP, SingleListenerCanAcceptManyClients) {
     return std::thread([&]() {
       auto context = std::make_shared<boost::asio::io_context>();
       auto upgrader = makeUpgrader();
-      auto transport =
-          std::make_shared<TcpTransport>(context, std::move(upgrader));
+      auto transport = std::make_shared<TcpTransport>(
+          context, mux_config, std::move(upgrader));
       transport->dial(testutil::randomPeerId(), ma, [context](auto &&rconn) {
         auto conn = expectConnectionValid(rconn);
 
@@ -208,7 +212,8 @@ TEST(TCP, SingleListenerCanAcceptManyClients) {
 TEST(TCP, DialToNoServer) {
   auto context = std::make_shared<boost::asio::io_context>();
   auto upgrader = makeUpgrader();
-  auto transport = std::make_shared<TcpTransport>(context, std::move(upgrader));
+  auto transport =
+      std::make_shared<TcpTransport>(context, mux_config, std::move(upgrader));
   auto ma = "/ip4/127.0.0.1/tcp/40003"_multiaddr;
 
   transport->dial(testutil::randomPeerId(), ma, [](auto &&rc) {
@@ -227,7 +232,8 @@ TEST(TCP, DialToNoServer) {
 TEST(TCP, ClientClosesConnection) {
   auto context = std::make_shared<boost::asio::io_context>(1);
   auto upgrader = makeUpgrader();
-  auto transport = std::make_shared<TcpTransport>(context, std::move(upgrader));
+  auto transport =
+      std::make_shared<TcpTransport>(context, mux_config, std::move(upgrader));
   auto listener = transport->createListener([&](auto &&rconn) {
     auto conn = expectConnectionValid(rconn);
     EXPECT_FALSE(conn->isInitiator());
@@ -259,7 +265,8 @@ TEST(TCP, ClientClosesConnection) {
 TEST(TCP, ServerClosesConnection) {
   auto context = std::make_shared<boost::asio::io_context>(1);
   auto upgrader = makeUpgrader();
-  auto transport = std::make_shared<TcpTransport>(context, std::move(upgrader));
+  auto transport =
+      std::make_shared<TcpTransport>(context, mux_config, std::move(upgrader));
   auto listener = transport->createListener([&](auto &&rconn) {
     auto conn = expectConnectionValid(rconn);
     EXPECT_FALSE(conn->isInitiator());
@@ -293,7 +300,8 @@ TEST(TCP, OneTransportServerHandlesManyClients) {
 
   auto context = std::make_shared<boost::asio::io_context>(1);
   auto upgrader = makeUpgrader();
-  auto transport = std::make_shared<TcpTransport>(context, std::move(upgrader));
+  auto transport =
+      std::make_shared<TcpTransport>(context, mux_config, std::move(upgrader));
   auto listener = transport->createListener([&](auto &&rconn) {
     auto conn = expectConnectionValid(rconn);
     EXPECT_FALSE(conn->isInitiator());

--- a/test/mock/libp2p/host/host_mock.hpp
+++ b/test/mock/libp2p/host/host_mock.hpp
@@ -31,18 +31,11 @@ namespace libp2p {
     MOCK_CONST_METHOD1(connectedness, Connectedness(const peer::PeerInfo &p));
     MOCK_METHOD3(setProtocolHandler,
                  void(StreamProtocols, StreamAndProtocolCb, ProtocolPredicate));
-    MOCK_METHOD3(connect,
-                 void(const peer::PeerInfo &,
-                      const ConnectionResultHandler &,
-                      std::chrono::milliseconds));
+    MOCK_METHOD2(connect,
+                 void(const peer::PeerInfo &, const ConnectionResultHandler &));
     MOCK_METHOD1(disconnect, void(const peer::PeerId &));
-    MOCK_METHOD4(newStream,
-                 void(const peer::PeerInfo &,
-                      StreamProtocols,
-                      StreamAndProtocolOrErrorCb,
-                      std::chrono::milliseconds));
     MOCK_METHOD3(newStream,
-                 void(const peer::PeerId &,
+                 void(const peer::PeerInfo &,
                       StreamProtocols,
                       StreamAndProtocolOrErrorCb));
     MOCK_METHOD1(listen, outcome::result<void>(const multi::Multiaddress &ma));

--- a/test/mock/libp2p/network/dialer_mock.hpp
+++ b/test/mock/libp2p/network/dialer_mock.hpp
@@ -16,17 +16,8 @@ namespace libp2p::network {
     ~DialerMock() override = default;
 
     MOCK_METHOD2(dial, void(const peer::PeerInfo &, DialResultFunc));
-    MOCK_METHOD3(dial,
-                 void(const peer::PeerInfo &,
-                      DialResultFunc,
-                      std::chrono::milliseconds));
-    MOCK_METHOD4(newStream,
-                 void(const peer::PeerInfo &,
-                      StreamProtocols,
-                      StreamAndProtocolOrErrorCb,
-                      std::chrono::milliseconds));
     MOCK_METHOD3(newStream,
-                 void(const peer::PeerId &,
+                 void(const peer::PeerInfo &,
                       StreamProtocols,
                       StreamAndProtocolOrErrorCb));
   };

--- a/test/mock/libp2p/peer/address_repository_mock.hpp
+++ b/test/mock/libp2p/peer/address_repository_mock.hpp
@@ -34,6 +34,11 @@ namespace libp2p::peer {
     MOCK_METHOD2(updateAddresses,
                  outcome::result<void>(const PeerId &, Milliseconds));
 
+    MOCK_METHOD(void,
+                dialFailed,
+                (const PeerId &, const Multiaddress &),
+                (override));
+
     MOCK_CONST_METHOD1(
         getAddresses,
         outcome::result<std::vector<multi::Multiaddress>>(const PeerId &));


### PR DESCRIPTION
- move "timeout" from `connect`/`dial`/`newStream` to config
- move failed addr to back, so next dial will try other addrs first.
  some peers have both good and bad addrs.
  but `set`/`unordered_set` didn't preserve order.