### PR TITLE
Removed NDEBUG tracking for compiling tests in Release mode

### DIFF
--- a/include/libp2p/multi/multiaddress_protocol_list.hpp
+++ b/include/libp2p/multi/multiaddress_protocol_list.hpp
@@ -58,12 +58,11 @@ namespace libp2p::multi {
       X_PARITY_WS = 4770,
       X_PARITY_WSS = 4780,
     // Range for private use: 0x300000 – 0x3FFFFF
-#ifndef NDEBUG
+    // Debug section
       _DUMMY_PROTO_1 = 0x3DEAD1,
       _DUMMY_PROTO_2 = 0x3DEAD2,
       _DUMMY_PROTO_3 = 0x3DEAD3,
       _DUMMY_PROTO_4 = 0x3DEAD4,
-#endif
     };
 
     constexpr bool operator==(const Protocol &p) const {
@@ -82,12 +81,9 @@ namespace libp2p::multi {
    public:
     /**
      * The total number of known protocols
+     * (31 ordinal + 4 debug)
      */
-    static constexpr size_t kProtocolsNum = 31
-#ifndef NDEBUG
-                                          + 4
-#endif
-        ;
+    static constexpr size_t kProtocolsNum = 31 + 4;
 
     /**
      * Returns a protocol with the corresponding name if it exists, or nullptr
@@ -164,12 +160,12 @@ namespace libp2p::multi {
         {Protocol::Code::P2P_CIRCUIT, 0, "p2p-circuit"},
         {Protocol::Code::X_PARITY_WS, Protocol::kVarLen, "x-parity-ws"},
         {Protocol::Code::X_PARITY_WSS, Protocol::kVarLen, "x-parity-wss"},
-#ifndef NDEBUG
+// Debug section
         {Protocol::Code::_DUMMY_PROTO_1, 0, "_dummy_proto_1"},
         {Protocol::Code::_DUMMY_PROTO_2, 0, "_dummy_proto_2"},
         {Protocol::Code::_DUMMY_PROTO_3, Protocol::kVarLen, "_dummy_proto_3"},
         {Protocol::Code::_DUMMY_PROTO_4, Protocol::kVarLen, "_dummy_proto_4"},
-#endif
+
     };
   };
 


### PR DESCRIPTION
I am preparing this implementation to be distributed as a Debian package. It requires running all the available tests despite the `Debug` or `Release` build type being selected for CMake. The presence of `NDEBUG` definition tracking in the code removes this possibility because the absence of the `_DUMMY_PROTO_` section in `multiaddress_protocol_list.h` allows successful compilation only when the tests are not compiled. Otherwise, the following error occurs:
```
/home/twdragon/src/libp2p-cpp/test/libp2p/transport/upgrader_test.cpp:76:38: error: no member named '_DUMMY_PROTO_1' in 'libp2p::multi::Protocol::Code'
      libp2p::multi::Protocol::Code::_DUMMY_PROTO_1,
      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
/home/twdragon/src/libp2p-cpp/test/libp2p/transport/upgrader_test.cpp:77:38: error: no member named '_DUMMY_PROTO_2' in 'libp2p::multi::Protocol::Code'
      libp2p::multi::Protocol::Code::_DUMMY_PROTO_2,
      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
2 errors generated.
```

This PR proposes removing `NDEBUG` tracking from the code so the tests would be compiled and run when `CMAKE_BUILD_TYPE` is set to `Release`.