### PR TITLE
Fix close YamuxedConnection

### DIFF
--- a/src/muxer/yamux/yamuxed_connection.cpp
+++ b/src/muxer/yamux/yamuxed_connection.cpp
@@ -533,6 +533,8 @@ namespace libp2p::connection {
       return;
     }
 
+    // Keep alive until method completion
+    auto self = shared_from_this();
     started_ = false;
 
     SL_DEBUG(log(), "closing connection, reason: {}", notify_streams_code);

--- a/src/muxer/yamux/yamuxed_connection.cpp
+++ b/src/muxer/yamux/yamuxed_connection.cpp
@@ -714,7 +714,11 @@ namespace libp2p::connection {
                "scheduling expire timer to {} msec",
                config_.no_streams_interval.count());
       inactivity_handle_ = scheduler_->scheduleWithHandle(
-          [this] { onExpireTimer(); },
+          [weak_ptr(weak_from_this())] {
+            if (auto self = weak_ptr.lock()) {
+              self->onExpireTimer();
+            }
+          },
           scheduler_->now() + config_.no_streams_interval);
     }
   }


### PR DESCRIPTION
We obtained the following core dump during KAGOME testing (that uses cpp-libp2p):
[gdb.txt](https://github.com/user-attachments/files/19428624/gdb.txt)

In particular we see:

```cpp
#8  0x000055e7e280a972 in libp2p::connection::YamuxedConnection::~YamuxedConnection() ()
...
#11 0x000055e7e281005d in libp2p::connection::YamuxedConnection::close(std::error_code, boost::optional<libp2p::connection::YamuxFrame::GoAwayError>) ()
```

which is the evidence that `YamuxedConnection` was destroyed during `close` method invocation.
This could potentially happen if during
```cpp
closed_callback_(remote_peer_, shared_from_this());
```
destruction of current `YamuxedConnection` was triggered and therefore second attempt to destroy `YamuxedConnection` lead to double free.

As a workaround it is proposed to keep `YamuxedConnection` alive during `close`
