### PR TITLE
Removed assert from `KademliaImpl::start`

### DIFF
--- a/src/protocol/kademlia/impl/kademlia_impl.cpp
+++ b/src/protocol/kademlia/impl/kademlia_impl.cpp
@@ -58,7 +58,6 @@ namespace libp2p::protocol::kademlia {
   }
 
   void KademliaImpl::start() {
-    BOOST_ASSERT(not started_);
     if (started_) {
       return;
     }


### PR DESCRIPTION
This assert does not make sense when immediately after it there is another check for it that simply returns.