### PR TITLE
Refactor read/write mock

### DIFF
--- a/test/libp2p/connection/security_conn/plaintext_connection_test.cpp
+++ b/test/libp2p/connection/security_conn/plaintext_connection_test.cpp
@@ -11,6 +11,8 @@
 #include <qtils/test/outcome.hpp>
 #include "mock/libp2p/connection/layer_connection_mock.hpp"
 #include "mock/libp2p/crypto/key_marshaller_mock.hpp"
+#include "testutil/expect_read.hpp"
+#include "testutil/expect_write.hpp"
 #include "testutil/gmock_actions.hpp"
 
 using namespace libp2p::connection;
@@ -120,28 +122,11 @@ TEST_F(PlaintextConnectionTest, RemoteMultiaddr) {
  */
 TEST_F(PlaintextConnectionTest, Read) {
   const int size = 100;
-  EXPECT_CALL(*connection_, read(_, _, _)).WillOnce(AsioSuccess(size));
+  EXPECT_CALL_READ(*connection_).WILL_READ_SIZE(size);
   auto buf = std::make_shared<std::vector<uint8_t>>(size, 0);
   secure_connection_->read(*buf, size, [size, buf](auto &&res) {
     ASSERT_OUTCOME_SUCCESS(res);
     ASSERT_EQ(res.value(), size);
-  });
-}
-
-/**
- * @given plaintext secure connection
- * @when invoking readSome method of the connection
- * @then method behaves as expected
- */
-TEST_F(PlaintextConnectionTest, ReadSome) {
-  const int size = 100;
-  const int smaller = 50;
-  EXPECT_CALL(*connection_, readSome(_, _, _))
-      .WillOnce(AsioSuccess(smaller /* less than 100 */));
-  auto buf = std::make_shared<std::vector<uint8_t>>(size, 0);
-  secure_connection_->readSome(*buf, smaller, [smaller, buf](auto &&res) {
-    ASSERT_OUTCOME_SUCCESS(res);
-    ASSERT_EQ(res.value(), smaller);
   });
 }
 
@@ -152,28 +137,11 @@ TEST_F(PlaintextConnectionTest, ReadSome) {
  */
 TEST_F(PlaintextConnectionTest, Write) {
   const int size = 100;
-  EXPECT_CALL(*connection_, writeSome(_, _, _)).WillOnce(AsioSuccess(size));
+  EXPECT_CALL_WRITE(*connection_).WILL_WRITE_SIZE(size);
   auto buf = std::make_shared<std::vector<uint8_t>>(size, 0);
   libp2p::writeReturnSize(secure_connection_, *buf, [size, buf](auto &&res) {
     ASSERT_OUTCOME_SUCCESS(res);
     ASSERT_EQ(res.value(), size);
-  });
-}
-
-/**
- * @given plaintext secure connection
- * @when invoking writeSome method of the connection
- * @then method behaves as expected
- */
-TEST_F(PlaintextConnectionTest, WriteSome) {
-  const int size = 100;
-  const int smaller = 50;
-  EXPECT_CALL(*connection_, writeSome(_, _, _))
-      .WillOnce(AsioSuccess(smaller /* less than 100 */));
-  auto buf = std::make_shared<std::vector<uint8_t>>(size, 0);
-  secure_connection_->writeSome(*buf, smaller, [smaller, buf](auto &&res) {
-    ASSERT_OUTCOME_SUCCESS(res);
-    ASSERT_EQ(res.value(), smaller);
   });
 }
 

--- a/test/libp2p/protocol/echo_test.cpp
+++ b/test/libp2p/protocol/echo_test.cpp
@@ -6,8 +6,11 @@
 
 #include <gtest/gtest.h>
 #include <libp2p/protocol/echo.hpp>
+#include <qtils/bytestr.hpp>
 #include <qtils/test/outcome.hpp>
 #include "mock/libp2p/connection/stream_mock.hpp"
+#include "testutil/expect_read.hpp"
+#include "testutil/expect_write.hpp"
 #include "testutil/gmock_actions.hpp"
 #include "testutil/prepare_loggers.hpp"
 
@@ -17,30 +20,8 @@ using ::testing::_;
 using ::testing::Return;
 using std::string_literals::operator""s;
 
-// set what we read
-ACTION_P(SetReadMsg, msg) {
-  std::copy(msg.begin(), msg.end(), arg0.begin());
-  arg2(msg.size());
-}
-
-// assert that we write the same as we read
-ACTION_P(WriteMsgAssertEqual, msg) {
-  std::string sub;
-
-  if (*arg0.begin() == 0) {
-    // EOF
-    return;
-  }
-
-  auto begin = arg0.begin();
-  auto end = arg0.begin();
-
-  std::advance(end, msg.size());
-  std::copy(begin, end, std::back_inserter(sub));
-  EXPECT_EQ(sub, msg);
-
-  arg2(msg.size());
-}
+const auto msg = "hello"s;
+const auto msg_bytes = qtils::str2byte(msg);
 
 /**
  * @given Stream
@@ -52,7 +33,6 @@ TEST(EchoTest, Server) {
 
   Echo echo;
   auto stream = std::make_shared<connection::StreamMock>();
-  auto msg = "hello"s;
 
   EXPECT_CALL(*stream, isClosedForRead())
       .WillOnce(Return(false))
@@ -63,8 +43,8 @@ TEST(EchoTest, Server) {
   EXPECT_CALL(*stream, close(_))
       .WillOnce(Arg0CallbackWithArg(outcome::success()));
 
-  EXPECT_CALL(*stream, readSome(_, _, _)).WillOnce(SetReadMsg(msg));
-  EXPECT_CALL(*stream, writeSome(_, _, _)).WillOnce(WriteMsgAssertEqual(msg));
+  EXPECT_CALL_READ(*stream).WILL_READ(msg_bytes);
+  EXPECT_CALL_WRITE(*stream).WILL_WRITE(msg_bytes);
 
   echo.handle(StreamAndProtocol{stream, {}});
 }
@@ -74,15 +54,14 @@ TEST(EchoTest, Server) {
  * @when client writes string "hello" to the Stream
  * @then client reads back the same string
  */
-TEST(EchoTest, DISABLED_Client) {
+TEST(EchoTest, Client) {
   Echo echo;
   auto stream = std::make_shared<connection::StreamMock>();
-  auto msg = "hello"s;
 
   EXPECT_CALL(*stream, isClosedForWrite()).WillOnce(Return(false));
 
-  EXPECT_CALL(*stream, writeSome(_, _, _)).WillOnce(WriteMsgAssertEqual(msg));
-  EXPECT_CALL(*stream, readSome(_, _, _)).WillOnce(WriteMsgAssertEqual(msg));
+  EXPECT_CALL_READ(*stream).WILL_READ(msg_bytes).WILL_READ_ERROR();
+  EXPECT_CALL_WRITE(*stream).WILL_WRITE(msg_bytes);
 
   bool executed = false;
 

--- a/test/libp2p/protocol/identify_delta_test.cpp
+++ b/test/libp2p/protocol/identify_delta_test.cpp
@@ -19,6 +19,7 @@
 #include "mock/libp2p/network/connection_manager_mock.hpp"
 #include "mock/libp2p/peer/peer_repository_mock.hpp"
 #include "mock/libp2p/peer/protocol_repository_mock.hpp"
+#include "testutil/expect_read.hpp"
 #include "testutil/gmock_actions.hpp"
 #include "testutil/prepare_loggers.hpp"
 
@@ -154,12 +155,9 @@ ACTION_P(ReadPut, buf) {
  */
 TEST_F(IdentifyDeltaTest, Receive) {
   // handle
-  EXPECT_CALL(*stream_, read(_, 1, _))
-      .WillOnce(ReadPut(std::span(msg_added_rm_protos_bytes_.data(), 1)));
-  EXPECT_CALL(*stream_, read(_, added_rm_proto_len_.toUInt64(), _))
-      .WillOnce(ReadPut(std::span(
-          msg_added_rm_protos_bytes_.data() + added_proto_len_.size(),
-          msg_added_rm_protos_bytes_.size() - added_proto_len_.size())));
+  EXPECT_CALL_READ(*stream_)
+      .WILL_READ(BytesOut(msg_added_rm_protos_bytes_).first(1))
+      .WILL_READ(BytesOut(msg_added_rm_protos_bytes_).subspan(1));
 
   // deltaReceived
   EXPECT_CALL(*stream_, remotePeerId())

--- a/test/libp2p/security/plaintext_adaptor_test.cpp
+++ b/test/libp2p/security/plaintext_adaptor_test.cpp
@@ -44,9 +44,6 @@ class PlaintextAdaptorTest : public testing::Test {
     key_marshaller = std::make_shared<KeyMarshallerMock>();
     adaptor = std::make_shared<Plaintext>(marshaller, idmgr, key_marshaller);
 
-    ON_CALL(*conn, read(_, _, _)).WillByDefault(Arg2CallbackWithArg(5));
-    ON_CALL(*conn, writeSome(_, _, _)).WillByDefault(Arg2CallbackWithArg(5));
-
     ON_CALL(*idmgr, getKeyPair()).WillByDefault(ReturnRef(local_keypair));
     ON_CALL(*idmgr, getId()).WillByDefault(ReturnRef(local_pid));
     ON_CALL(*marshaller, marshal(_))

--- a/test/mock/libp2p/connection/layer_connection_mock.hpp
+++ b/test/mock/libp2p/connection/layer_connection_mock.hpp
@@ -7,12 +7,13 @@
 #pragma once
 
 #include <libp2p/connection/layer_connection.hpp>
+#include <libp2p/basic/read_return_size.hpp>
 
 #include <gmock/gmock.h>
 
 namespace libp2p::connection {
 
-  class LayerConnectionMock : public virtual LayerConnection {
+  class LayerConnectionMock : public std::enable_shared_from_this<LayerConnectionMock>, public virtual LayerConnection {
    public:
     ~LayerConnectionMock() override = default;
 
@@ -20,7 +21,12 @@ namespace libp2p::connection {
 
     MOCK_METHOD0(close, outcome::result<void>());
 
-    MOCK_METHOD3(read, void(BytesOut, size_t, Reader::ReadCallbackFunc));
+    void read(BytesOut out,
+              size_t ambigous_size,
+              Reader::ReadCallbackFunc cb) override {
+      ASSERT_EQ(out.size(), ambigous_size);
+      readReturnSize(shared_from_this(), out, cb);
+    }
     MOCK_METHOD3(readSome, void(BytesOut, size_t, Reader::ReadCallbackFunc));
     MOCK_METHOD3(writeSome, void(BytesIn, size_t, Writer::WriteCallbackFunc));
     MOCK_METHOD2(deferReadCallback,

--- a/test/mock/libp2p/connection/stream_mock.hpp
+++ b/test/mock/libp2p/connection/stream_mock.hpp
@@ -6,12 +6,14 @@
 
 #pragma once
 
+#include <libp2p/basic/read_return_size.hpp>
 #include <libp2p/connection/stream.hpp>
 
 #include <gmock/gmock.h>
 
 namespace libp2p::connection {
-  class StreamMock : public Stream {
+  class StreamMock : public std::enable_shared_from_this<StreamMock>,
+                     public Stream {
    public:
     ~StreamMock() override = default;
 
@@ -25,7 +27,12 @@ namespace libp2p::connection {
 
     MOCK_METHOD1(close, void(VoidResultHandlerFunc));
 
-    MOCK_METHOD3(read, void(BytesOut, size_t, Reader::ReadCallbackFunc));
+    void read(BytesOut out,
+              size_t ambigous_size,
+              Reader::ReadCallbackFunc cb) override {
+      ASSERT_EQ(out.size(), ambigous_size);
+      readReturnSize(shared_from_this(), out, cb);
+    }
     MOCK_METHOD3(readSome, void(BytesOut, size_t, Reader::ReadCallbackFunc));
     MOCK_METHOD3(writeSome, void(BytesIn, size_t, Writer::WriteCallbackFunc));
 

--- a/test/testutil/expect_read.hpp
+++ b/test/testutil/expect_read.hpp
@@ -1,0 +1,38 @@
+/**
+ * Copyright Quadrivium LLC
+ * All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <gtest/gtest.h>
+#include <qtils/bytes.hpp>
+
+#define EXPECT_CALL_READ(mock) \
+  EXPECT_CALL(mock, readSome(testing::_, testing::_, testing::_))
+#define WILL_READ(_expected)                                 \
+  WillOnce([expected{qtils::asVec(_expected)}](              \
+               libp2p::BytesOut out,                         \
+               size_t ambigous_size,                         \
+               libp2p::basic::Reader::ReadCallbackFunc cb) { \
+    ASSERT_EQ(out.size(), ambigous_size);                    \
+    ASSERT_GE(out.size(), expected.size());                  \
+    memcpy(out.data(), expected.data(), expected.size());    \
+    cb(expected.size());                                     \
+  })
+#define WILL_READ_SIZE(_expected)                                              \
+  WillOnce([expected{_expected}](libp2p::BytesOut out,                         \
+                                 size_t ambigous_size,                         \
+                                 libp2p::basic::Reader::ReadCallbackFunc cb) { \
+    ASSERT_EQ(out.size(), ambigous_size);                                      \
+    ASSERT_EQ(out.size(), expected);                                           \
+    cb(expected);                                                              \
+  })
+#define WILL_READ_ERROR()                                   \
+  WillOnce([](libp2p::BytesOut out,                         \
+              size_t ambigous_size,                         \
+              libp2p::basic::Reader::ReadCallbackFunc cb) { \
+    ASSERT_EQ(out.size(), ambigous_size);                   \
+    cb(std::errc::io_error);                                \
+  })

--- a/test/testutil/expect_write.hpp
+++ b/test/testutil/expect_write.hpp
@@ -1,0 +1,38 @@
+/**
+ * Copyright Quadrivium LLC
+ * All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+#include <gtest/gtest.h>
+#include <qtils/bytes.hpp>
+
+#define EXPECT_CALL_WRITE(mock) \
+  EXPECT_CALL(mock, writeSome(testing::_, testing::_, testing::_))
+#define WILL_WRITE(_expected)                                 \
+  WillOnce([expected{qtils::asVec(_expected)}](               \
+               libp2p::BytesIn in,                            \
+               size_t ambigous_size,                          \
+               libp2p::basic::Writer::WriteCallbackFunc cb) { \
+    ASSERT_EQ(in.size(), ambigous_size);                      \
+    ASSERT_EQ(qtils::asVec(in), expected);                    \
+    cb(in.size());                                            \
+  })
+#define WILL_WRITE_SIZE(_expected)                                         \
+  WillOnce(                                                                \
+      [expected{_expected}](libp2p::BytesIn in,                            \
+                            size_t ambigous_size,                          \
+                            libp2p::basic::Writer::WriteCallbackFunc cb) { \
+        ASSERT_EQ(in.size(), ambigous_size);                               \
+        ASSERT_EQ(in.size(), expected);                                    \
+        cb(expected);                                                      \
+      })
+#define WILL_WRITE_ERROR()                                   \
+  WillOnce([](libp2p::BytesIn in,                            \
+              size_t ambigous_size,                          \
+              libp2p::basic::Writer::WriteCallbackFunc cb) { \
+    ASSERT_EQ(in.size(), ambigous_size);                     \
+    cb(std::errc::io_error);                                 \
+  })


### PR DESCRIPTION
Added abstraction to read/write mock functionality to make it easily editable in case of changes to functions read, readSome, and, writeSome.