### PR TITLE
Removing Reader::read

### DIFF
--- a/include/libp2p/basic/reader.hpp
+++ b/include/libp2p/basic/reader.hpp
@@ -21,20 +21,6 @@ namespace libp2p::basic {
     virtual ~Reader() = default;
 
     /**
-     * @brief Reads exactly {@code} min(out.size(), bytes) {@nocode} bytes to
-     * the buffer.
-     * @param out output argument. Read data will be written to this buffer.
-     * @param bytes number of bytes to read
-     * @param cb callback with result of operation
-     *
-     * @note caller should maintain validity of an output buffer until callback
-     * is executed. It is usually done with either wrapping buffer as shared
-     * pointer, or having buffer as part of some class/struct, and using
-     * enable_shared_from_this()
-     */
-    virtual void read(BytesOut out, size_t bytes, ReadCallbackFunc cb) = 0;
-
-    /**
      * @brief Reads up to {@code} min(out.size(), bytes) {@nocode} bytes to the
      * buffer.
      * @param out output argument. Read data will be written to this buffer.

--- a/include/libp2p/connection/loopback_stream.hpp
+++ b/include/libp2p/connection/loopback_stream.hpp
@@ -40,8 +40,6 @@ namespace libp2p::connection {
         const override;
 
    protected:
-    void read(BytesOut out, size_t bytes, ReadCallbackFunc cb) override;
-
     void readSome(BytesOut out, size_t bytes, ReadCallbackFunc cb) override;
 
     void writeSome(BytesIn in, size_t bytes, WriteCallbackFunc cb) override;

--- a/include/libp2p/layer/websocket/ssl_connection.hpp
+++ b/include/libp2p/layer/websocket/ssl_connection.hpp
@@ -32,7 +32,6 @@ namespace libp2p::connection {
     outcome::result<void> close() override;
     bool isClosed() const override;
 
-    void read(BytesOut out, size_t bytes, ReadCallbackFunc cb) override;
     void readSome(BytesOut out, size_t bytes, ReadCallbackFunc cb) override;
     void deferReadCallback(outcome::result<size_t> res,
                            ReadCallbackFunc cb) override;

--- a/include/libp2p/layer/websocket/ws_connection.hpp
+++ b/include/libp2p/layer/websocket/ws_connection.hpp
@@ -68,8 +68,6 @@ namespace libp2p::connection {
 
     bool isClosed() const override;
 
-    void read(BytesOut out, size_t bytes, ReadCallbackFunc cb) override;
-
     void readSome(BytesOut out, size_t bytes, ReadCallbackFunc cb) override;
 
     void deferReadCallback(outcome::result<size_t> res,

--- a/include/libp2p/muxer/mplex/mplex_stream.hpp
+++ b/include/libp2p/muxer/mplex/mplex_stream.hpp
@@ -50,8 +50,6 @@ namespace libp2p::connection {
 
     ~MplexStream() override = default;
 
-    void read(BytesOut out, size_t bytes, ReadCallbackFunc cb) override;
-
     void readSome(BytesOut out, size_t bytes, ReadCallbackFunc cb) override;
 
     void deferReadCallback(outcome::result<size_t> res,

--- a/include/libp2p/muxer/mplex/mplexed_connection.hpp
+++ b/include/libp2p/muxer/mplex/mplexed_connection.hpp
@@ -64,7 +64,6 @@ namespace libp2p::connection {
 
     /// usage of these four methods is highly not recommended or even forbidden:
     /// use stream over this connection instead
-    void read(BytesOut out, size_t bytes, ReadCallbackFunc cb) override;
     void readSome(BytesOut out, size_t bytes, ReadCallbackFunc cb) override;
     void writeSome(BytesIn in, size_t bytes, WriteCallbackFunc cb) override;
 

--- a/include/libp2p/muxer/yamux/yamux_stream.hpp
+++ b/include/libp2p/muxer/yamux/yamux_stream.hpp
@@ -54,8 +54,6 @@ namespace libp2p::connection {
                 size_t maximum_window_size,
                 size_t write_queue_limit);
 
-    void read(BytesOut out, size_t bytes, ReadCallbackFunc cb) override;
-
     void readSome(BytesOut out, size_t bytes, ReadCallbackFunc cb) override;
 
     void deferReadCallback(outcome::result<size_t> res,

--- a/include/libp2p/muxer/yamux/yamuxed_connection.hpp
+++ b/include/libp2p/muxer/yamux/yamuxed_connection.hpp
@@ -111,7 +111,6 @@ namespace libp2p::connection {
 
     /// usage of these four methods is highly not recommended or even forbidden:
     /// use stream over this connection instead
-    void read(BytesOut out, size_t bytes, ReadCallbackFunc cb) override;
     void readSome(BytesOut out, size_t bytes, ReadCallbackFunc cb) override;
     void writeSome(BytesIn in, size_t bytes, WriteCallbackFunc cb) override;
 

--- a/include/libp2p/security/noise/noise_connection.hpp
+++ b/include/libp2p/security/noise/noise_connection.hpp
@@ -38,8 +38,6 @@ namespace libp2p::connection {
 
     outcome::result<void> close() override;
 
-    void read(BytesOut out, size_t bytes, ReadCallbackFunc cb) override;
-
     void readSome(BytesOut out, size_t bytes, ReadCallbackFunc cb) override;
 
     void deferReadCallback(outcome::result<size_t> res,

--- a/include/libp2p/security/plaintext/plaintext_connection.hpp
+++ b/include/libp2p/security/plaintext/plaintext_connection.hpp
@@ -35,8 +35,6 @@ namespace libp2p::connection {
 
     outcome::result<multi::Multiaddress> remoteMultiaddr() override;
 
-    void read(BytesOut out, size_t bytes, ReadCallbackFunc cb) override;
-
     void readSome(BytesOut out, size_t bytes, ReadCallbackFunc cb) override;
 
     void deferReadCallback(outcome::result<size_t> res,

--- a/include/libp2p/security/secio/secio_connection.hpp
+++ b/include/libp2p/security/secio/secio_connection.hpp
@@ -97,8 +97,6 @@ namespace libp2p::connection {
 
     outcome::result<multi::Multiaddress> remoteMultiaddr() override;
 
-    void read(BytesOut out, size_t bytes, ReadCallbackFunc cb) override;
-
     void readSome(BytesOut out, size_t bytes, ReadCallbackFunc cb) override;
 
     void deferReadCallback(outcome::result<size_t> res,

--- a/include/libp2p/transport/quic/connection.hpp
+++ b/include/libp2p/transport/quic/connection.hpp
@@ -39,7 +39,6 @@ namespace libp2p::transport {
     void operator=(QuicConnection &&) = delete;
 
     // Reader
-    void read(BytesOut out, size_t bytes, ReadCallbackFunc cb) override;
     void readSome(BytesOut out, size_t bytes, ReadCallbackFunc cb) override;
     void deferReadCallback(outcome::result<size_t> res,
                            ReadCallbackFunc cb) override;

--- a/include/libp2p/transport/quic/stream.hpp
+++ b/include/libp2p/transport/quic/stream.hpp
@@ -32,7 +32,6 @@ namespace libp2p::connection {
     void operator=(QuicStream &&) = delete;
 
     // Reader
-    void read(BytesOut out, size_t bytes, ReadCallbackFunc cb) override;
     void readSome(BytesOut out, size_t bytes, ReadCallbackFunc cb) override;
     void deferReadCallback(outcome::result<size_t> res,
                            ReadCallbackFunc cb) override;

--- a/include/libp2p/transport/tcp/tcp_connection.hpp
+++ b/include/libp2p/transport/tcp/tcp_connection.hpp
@@ -61,8 +61,6 @@ namespace libp2p::transport {
                  ConnectCallbackFunc cb,
                  std::chrono::milliseconds timeout);
 
-    void read(BytesOut out, size_t bytes, ReadCallbackFunc cb) override;
-
     void readSome(BytesOut out, size_t bytes, ReadCallbackFunc cb) override;
 
     void deferReadCallback(outcome::result<size_t> res,

--- a/src/basic/message_read_writer_uvarint.cpp
+++ b/src/basic/message_read_writer_uvarint.cpp
@@ -11,6 +11,7 @@
 #include <boost/assert.hpp>
 #include <boost/optional.hpp>
 #include <libp2p/basic/message_read_writer_error.hpp>
+#include <libp2p/basic/read_return_size.hpp>
 #include <libp2p/basic/varint_reader.hpp>
 #include <libp2p/basic/write_return_size.hpp>
 #include <libp2p/multi/uvarint.hpp>
@@ -34,9 +35,9 @@ namespace libp2p::basic {
           auto msg_len = varint_res.value().toUInt64();
           if (0 != msg_len) {
             auto buffer = std::make_shared<std::vector<uint8_t>>(msg_len, 0);
-            self->conn_->read(
+            readReturnSize(
+                self->conn_,
                 *buffer,
-                msg_len,
                 [self, buffer, cb = std::move(cb)](auto &&res) mutable {
                   if (!res) {
                     return cb(res.error());

--- a/src/basic/varint_reader.cpp
+++ b/src/basic/varint_reader.cpp
@@ -48,7 +48,7 @@ namespace libp2p::basic {
     readReturnSize(
         conn,
         std::span(varint_buf->data() + current_length, 1),
-        [c = std::move(conn), cb = std::move(cb), current_length, varint_buf](
+        [c = conn, cb = std::move(cb), current_length, varint_buf](
             auto &&res) mutable {
           if (not res.has_value()) {
             return cb(res.error());

--- a/src/basic/varint_reader.cpp
+++ b/src/basic/varint_reader.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <libp2p/basic/varint_reader.hpp>
+#include <libp2p/basic/read_return_size.hpp>
 
 #include <vector>
 
@@ -44,9 +45,9 @@ namespace libp2p::basic {
     }
 
     // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-    conn->read(
+    readReturnSize(
+        conn,
         std::span(varint_buf->data() + current_length, 1),
-        1,
         [c = std::move(conn), cb = std::move(cb), current_length, varint_buf](
             auto &&res) mutable {
           if (not res.has_value()) {

--- a/src/connection/loopback_stream.cpp
+++ b/src/connection/loopback_stream.cpp
@@ -77,13 +77,6 @@ namespace libp2p::connection {
     return outcome::success(own_peer_info_.addresses.front());
   }
 
-  void LoopbackStream::read(BytesOut out,
-                            size_t bytes,
-                            libp2p::basic::Reader::ReadCallbackFunc cb) {
-    ambigousSize(out, bytes);
-    readReturnSize(shared_from_this(), out, std::move(cb));
-  }
-
   void LoopbackStream::writeSome(BytesIn in,
                                  size_t bytes,
                                  libp2p::basic::Writer::WriteCallbackFunc cb) {

--- a/src/layer/websocket/ssl_connection.cpp
+++ b/src/layer/websocket/ssl_connection.cpp
@@ -43,13 +43,6 @@ namespace libp2p::connection {
     return connection_->close();
   }
 
-  void SslConnection::read(BytesOut out,
-                           size_t bytes,
-                           libp2p::basic::Reader::ReadCallbackFunc cb) {
-    ambigousSize(out, bytes);
-    readReturnSize(shared_from_this(), out, std::move(cb));
-  }
-
   void SslConnection::readSome(BytesOut out,
                                size_t bytes,
                                libp2p::basic::Reader::ReadCallbackFunc cb) {

--- a/src/layer/websocket/ws_connection.cpp
+++ b/src/layer/websocket/ws_connection.cpp
@@ -85,14 +85,6 @@ namespace libp2p::connection {
     return connection_->close();
   }
 
-  void WsConnection::read(BytesOut out,
-                          size_t bytes,
-                          libp2p::basic::Reader::ReadCallbackFunc cb) {
-    ambigousSize(out, bytes);
-    SL_TRACE(log_, "read {} bytes", bytes);
-    readReturnSize(shared_from_this(), out, std::move(cb));
-  }
-
   void WsConnection::readSome(BytesOut out,
                               size_t bytes,
                               libp2p::basic::Reader::ReadCallbackFunc cb) {

--- a/src/muxer/mplex/mplex_frame.cpp
+++ b/src/muxer/mplex/mplex_frame.cpp
@@ -6,6 +6,7 @@
 
 #include <libp2p/muxer/mplex/mplex_frame.hpp>
 
+#include <libp2p/basic/read_return_size.hpp>
 #include <libp2p/basic/varint_reader.hpp>
 #include <libp2p/multi/uvarint.hpp>
 #include <libp2p/muxer/mplex/mplexed_connection.hpp>
@@ -100,16 +101,16 @@ namespace libp2p::connection {
                 // read data
                 std::shared_ptr<Bytes> data =
                     std::make_shared<Bytes>(length, 0);
-                reader->read(*data,
-                             length,
-                             [id_flag, data, cb{std::move(cb)}](
-                                 auto &&read_res) mutable {
-                               if (!read_res) {
-                                 return cb(read_res.error());
-                               }
+                readReturnSize(reader,
+                               *data,
+                               [id_flag, data, cb{std::move(cb)}](
+                                   auto &&read_res) mutable {
+                                 if (!read_res) {
+                                   return cb(read_res.error());
+                                 }
 
-                               cb(createFrame(id_flag, std::move(*data)));
-                             });
+                                 cb(createFrame(id_flag, std::move(*data)));
+                               });
               });
         });
   }

--- a/src/muxer/mplex/mplex_stream.cpp
+++ b/src/muxer/mplex/mplex_stream.cpp
@@ -34,11 +34,6 @@ namespace libp2p::connection {
                            StreamId stream_id)
       : connection_{std::move(connection)}, stream_id_{stream_id} {}
 
-  void MplexStream::read(BytesOut out, size_t bytes, ReadCallbackFunc cb) {
-    ambigousSize(out, bytes);
-    readReturnSize(shared_from_this(), out, std::move(cb));
-  }
-
   void MplexStream::readDone(outcome::result<size_t> res) {
     auto cb{std::move(reading_->cb)};
     reading_.reset();

--- a/src/muxer/mplex/mplexed_connection.cpp
+++ b/src/muxer/mplex/mplexed_connection.cpp
@@ -125,12 +125,6 @@ namespace libp2p::connection {
     return !is_active_ || connection_->isClosed();
   }
 
-  void MplexedConnection::read(BytesOut out,
-                               size_t bytes,
-                               ReadCallbackFunc cb) {
-    readReturnSize(connection_, out, std::move(cb));
-  }
-
   void MplexedConnection::readSome(BytesOut out,
                                    size_t bytes,
                                    ReadCallbackFunc cb) {

--- a/src/muxer/mplex/mplexed_connection.cpp
+++ b/src/muxer/mplex/mplexed_connection.cpp
@@ -7,6 +7,7 @@
 #include <libp2p/muxer/mplex/mplexed_connection.hpp>
 
 #include <boost/assert.hpp>
+#include <libp2p/basic/read_return_size.hpp>
 #include <libp2p/basic/write_return_size.hpp>
 #include <libp2p/muxer/mplex/mplex_frame.hpp>
 
@@ -127,7 +128,7 @@ namespace libp2p::connection {
   void MplexedConnection::read(BytesOut out,
                                size_t bytes,
                                ReadCallbackFunc cb) {
-    connection_->read(out, bytes, std::move(cb));
+    readReturnSize(connection_, out, std::move(cb));
   }
 
   void MplexedConnection::readSome(BytesOut out,

--- a/src/muxer/yamux/yamux_stream.cpp
+++ b/src/muxer/yamux/yamux_stream.cpp
@@ -67,11 +67,6 @@ namespace libp2p::connection {
     assert(write_queue_limit >= maximum_window_size_);
   }
 
-  void YamuxStream::read(BytesOut out, size_t bytes, ReadCallbackFunc cb) {
-    ambigousSize(out, bytes);
-    readReturnSize(shared_from_this(), out, std::move(cb));
-  }
-
   void YamuxStream::readSome(BytesOut out, size_t bytes, ReadCallbackFunc cb) {
     ambigousSize(out, bytes);
     doRead(out, std::move(cb));

--- a/src/muxer/yamux/yamuxed_connection.cpp
+++ b/src/muxer/yamux/yamuxed_connection.cpp
@@ -163,13 +163,6 @@ namespace libp2p::connection {
     return !started_ || connection_->isClosed();
   }
 
-  void YamuxedConnection::read(BytesOut out,
-                               size_t bytes,
-                               ReadCallbackFunc cb) {
-    log()->error("YamuxedConnection::read : invalid direct call");
-    deferReadCallback(Error::CONNECTION_DIRECT_IO_FORBIDDEN, std::move(cb));
-  }
-
   void YamuxedConnection::readSome(BytesOut out,
                                    size_t bytes,
                                    ReadCallbackFunc cb) {

--- a/src/protocol/gossip/impl/stream.cpp
+++ b/src/protocol/gossip/impl/stream.cpp
@@ -8,6 +8,7 @@
 
 #include <cassert>
 
+#include <libp2p/basic/read_return_size.hpp>
 #include <libp2p/basic/varint_reader.hpp>
 #include <libp2p/basic/write_return_size.hpp>
 
@@ -83,15 +84,15 @@ namespace libp2p::protocol::gossip {
 
     read_buffer_->resize(msg_len);
 
-    stream_->read(std::span(read_buffer_->data(), msg_len),
-                  msg_len,
-                  [self_wptr = weak_from_this(), this, buffer = read_buffer_](
-                      auto &&res) {
-                    if (self_wptr.expired()) {
-                      return;
-                    }
-                    onMessageRead(std::forward<decltype(res)>(res));
-                  });
+    readReturnSize(stream_,
+                   std::span(read_buffer_->data(), msg_len),
+                   [self_wptr = weak_from_this(), this, buffer = read_buffer_](
+                       auto &&res) {
+                     if (self_wptr.expired()) {
+                       return;
+                     }
+                     onMessageRead(std::forward<decltype(res)>(res));
+                   });
   }
 
   void Stream::onMessageRead(outcome::result<size_t> res) {

--- a/src/protocol/ping/ping_client_session.cpp
+++ b/src/protocol/ping/ping_client_session.cpp
@@ -7,6 +7,7 @@
 #include <libp2p/protocol/ping/ping_client_session.hpp>
 
 #include <boost/assert.hpp>
+#include <libp2p/basic/read_return_size.hpp>
 #include <libp2p/basic/write_return_size.hpp>
 #include <libp2p/protocol/ping/common.hpp>
 
@@ -84,11 +85,11 @@ namespace libp2p::protocol {
         },
         config_.timeout);
 
-    stream_->read(read_buffer_,
-                  config_.message_size,
-                  [self{shared_from_this()}](outcome::result<size_t> r) {
-                    self->readCompleted(r);
-                  });
+    readReturnSize(stream_,
+                   read_buffer_,
+                   [self{shared_from_this()}](outcome::result<size_t> r) {
+                     self->readCompleted(r);
+                   });
   }
 
   void PingClientSession::readCompleted(outcome::result<size_t> r) {

--- a/src/protocol/ping/ping_server_session.cpp
+++ b/src/protocol/ping/ping_server_session.cpp
@@ -7,6 +7,7 @@
 #include <libp2p/protocol/ping/ping_server_session.hpp>
 
 #include <boost/assert.hpp>
+#include <libp2p/basic/read_return_size.hpp>
 #include <libp2p/basic/write_return_size.hpp>
 #include <libp2p/protocol/ping/common.hpp>
 
@@ -31,14 +32,13 @@ namespace libp2p::protocol {
       return;
     }
 
-    stream_->read(buffer_,
-                  config_.message_size,
-                  [self{shared_from_this()}](auto &&read_res) {
-                    if (!read_res) {
-                      return;
-                    }
-                    self->readCompleted();
-                  });
+    readReturnSize(
+        stream_, buffer_, [self{shared_from_this()}](auto &&read_res) {
+          if (!read_res) {
+            return;
+          }
+          self->readCompleted();
+        });
   }
 
   void PingServerSession::readCompleted() {

--- a/src/protocol_muxer/multiselect/multiselect_instance.cpp
+++ b/src/protocol_muxer/multiselect/multiselect_instance.cpp
@@ -9,6 +9,7 @@
 #include <cctype>
 #include <span>
 
+#include <libp2p/basic/read_return_size.hpp>
 #include <libp2p/basic/scheduler.hpp>
 #include <libp2p/basic/write_return_size.hpp>
 #include <libp2p/common/trace.hpp>
@@ -213,16 +214,16 @@ namespace libp2p::protocol_muxer::multiselect {
     BytesOut span(*read_buffer_);
     span = span.first(static_cast<Parser::IndexType>(bytes_needed));
 
-    connection_->read(span,
-                      bytes_needed,
-                      [wptr = weak_from_this(),
-                       round = current_round_,
-                       packet = read_buffer_](outcome::result<size_t> res) {
-                        auto self = wptr.lock();
-                        if (self && self->current_round_ == round) {
-                          self->onDataRead(res);
-                        }
-                      });
+    readReturnSize(connection_,
+                   span,
+                   [wptr = weak_from_this(),
+                    round = current_round_,
+                    packet = read_buffer_](outcome::result<size_t> res) {
+                     auto self = wptr.lock();
+                     if (self && self->current_round_ == round) {
+                       self->onDataRead(res);
+                     }
+                   });
   }
 
   void MultiselectInstance::onDataRead(outcome::result<size_t> res) {

--- a/src/protocol_muxer/multiselect/simple_stream_negotiate.cpp
+++ b/src/protocol_muxer/multiselect/simple_stream_negotiate.cpp
@@ -6,6 +6,7 @@
 
 #include <libp2p/protocol_muxer/multiselect/simple_stream_negotiate.hpp>
 
+#include <libp2p/basic/read_return_size.hpp>
 #include <libp2p/basic/write_return_size.hpp>
 #include <libp2p/log/logger.hpp>
 #include <libp2p/protocol_muxer/multiselect/serializing.hpp>
@@ -76,9 +77,9 @@ namespace libp2p::protocol_muxer::multiselect {
       // NOLINTNEXTLINE(cppcoreguidelines-narrowing-conversions)
       span = span.subspan(kMaxVarintSize, remaining_bytes);
 
-      stream->read(
+      readReturnSize(
+          stream,
           span,
-          span.size(),
           [stream = stream, cb = std::move(cb), buffers = std::move(buffers)](
               outcome::result<size_t> res) mutable {
             onLastBytesRead(std::move(stream), cb, *buffers, res);
@@ -100,9 +101,9 @@ namespace libp2p::protocol_muxer::multiselect {
       BytesOut span(buffers->read);
       span = span.first(kMaxVarintSize);
 
-      stream->read(
+      readReturnSize(
+          stream,
           span,
-          span.size(),
           [stream = stream, cb = std::move(cb), buffers = std::move(buffers)](
               outcome::result<size_t> res) mutable {
             onFirstBytesRead(stream, std::move(cb), std::move(buffers), res);

--- a/src/security/noise/noise_connection.cpp
+++ b/src/security/noise/noise_connection.cpp
@@ -46,13 +46,6 @@ namespace libp2p::connection {
     return connection_->close();
   }
 
-  void NoiseConnection::read(BytesOut out,
-                             size_t bytes,
-                             libp2p::basic::Reader::ReadCallbackFunc cb) {
-    ambigousSize(out, bytes);
-    readReturnSize(shared_from_this(), out, std::move(cb));
-  }
-
   void NoiseConnection::readSome(BytesOut out,
                                  size_t bytes,
                                  libp2p::basic::Reader::ReadCallbackFunc cb) {

--- a/src/security/plaintext/plaintext_connection.cpp
+++ b/src/security/plaintext/plaintext_connection.cpp
@@ -7,6 +7,7 @@
 #include <libp2p/security/plaintext/plaintext_connection.hpp>
 
 #include <boost/assert.hpp>
+#include <libp2p/basic/read_return_size.hpp>
 #include <libp2p/crypto/protobuf/protobuf_key.hpp>
 
 namespace libp2p::connection {
@@ -60,7 +61,7 @@ namespace libp2p::connection {
   void PlaintextConnection::read(BytesOut in,
                                  size_t bytes,
                                  Reader::ReadCallbackFunc f) {
-    return original_connection_->read(in, bytes, std::move(f));
+    return readReturnSize(original_connection_, in, std::move(f));
   };
 
   void PlaintextConnection::readSome(BytesOut in,

--- a/src/security/plaintext/plaintext_connection.cpp
+++ b/src/security/plaintext/plaintext_connection.cpp
@@ -58,12 +58,6 @@ namespace libp2p::connection {
     return original_connection_->remoteMultiaddr();
   }
 
-  void PlaintextConnection::read(BytesOut in,
-                                 size_t bytes,
-                                 Reader::ReadCallbackFunc f) {
-    return readReturnSize(original_connection_, in, std::move(f));
-  };
-
   void PlaintextConnection::readSome(BytesOut in,
                                      size_t bytes,
                                      Reader::ReadCallbackFunc f) {

--- a/src/security/secio/secio.cpp
+++ b/src/security/secio/secio.cpp
@@ -8,6 +8,7 @@
 
 #include <generated/security/secio/protobuf/secio.pb.h>
 #include <libp2p/basic/protobuf_message_read_writer.hpp>
+#include <libp2p/basic/read_return_size.hpp>
 #include <libp2p/basic/write_return_size.hpp>
 #include <libp2p/crypto/sha/sha256.hpp>
 #include <libp2p/security/error.hpp>
@@ -265,9 +266,9 @@ namespace libp2p::security {
                 }
                 const auto kToRead{self->propose_message_.rand.size()};
                 auto buffer = std::make_shared<Bytes>(kToRead);
-                secio_conn->read(
+                readReturnSize(
+                    secio_conn,
                     *buffer,
-                    kToRead,
                     [self, cb, conn, secio_conn, buffer](auto &&read_res) {
                       SECIO_OUTCOME_TRY(read_bytes, read_res, conn, cb)
                       if (read_bytes != buffer->size()

--- a/src/security/secio/secio_connection.cpp
+++ b/src/security/secio/secio_connection.cpp
@@ -183,13 +183,6 @@ namespace libp2p::connection {
     }
   }
 
-  void SecioConnection::read(BytesOut out,
-                             size_t bytes,
-                             basic::Reader::ReadCallbackFunc cb) {
-    ambigousSize(out, bytes);
-    libp2p::readReturnSize(shared_from_this(), out, std::move(cb));
-  }
-
   void SecioConnection::readSome(BytesOut out,
                                  size_t bytes,
                                  basic::Reader::ReadCallbackFunc cb) {

--- a/src/security/tls/tls_connection.cpp
+++ b/src/security/tls/tls_connection.cpp
@@ -140,14 +140,6 @@ namespace libp2p::connection {
     };
   }
 
-  void TlsConnection::read(BytesOut out,
-                           size_t bytes,
-                           Reader::ReadCallbackFunc f) {
-    ambigousSize(out, bytes);
-    SL_TRACE(log(), "reading {} bytes", bytes);
-    readReturnSize(shared_from_this(), out, std::move(f));
-  }
-
   void TlsConnection::readSome(BytesOut out,
                                size_t bytes,
                                Reader::ReadCallbackFunc cb) {

--- a/src/security/tls/tls_connection.hpp
+++ b/src/security/tls/tls_connection.hpp
@@ -76,9 +76,6 @@ namespace libp2p::connection {
     /// Returns remote network address
     outcome::result<multi::Multiaddress> remoteMultiaddr() override;
 
-    /// Async reads exactly the # of bytes given
-    void read(BytesOut out, size_t bytes, ReadCallbackFunc cb) override;
-
     /// Async reads up to the # of bytes given
     void readSome(BytesOut out, size_t bytes, ReadCallbackFunc cb) override;
 

--- a/src/transport/quic/connection.cpp
+++ b/src/transport/quic/connection.cpp
@@ -32,10 +32,6 @@ namespace libp2p::transport {
     std::ignore = close();
   }
 
-  void QuicConnection::read(BytesOut out, size_t bytes, ReadCallbackFunc cb) {
-    throw std::logic_error{"QuicConnection::read must not be called"};
-  }
-
   void QuicConnection::readSome(BytesOut out,
                                 size_t bytes,
                                 ReadCallbackFunc cb) {

--- a/src/transport/quic/stream.cpp
+++ b/src/transport/quic/stream.cpp
@@ -26,13 +26,6 @@ namespace libp2p::connection {
     reset();
   }
 
-  void QuicStream::read(BytesOut out,
-                        size_t bytes,
-                        basic::Reader::ReadCallbackFunc cb) {
-    ambigousSize(out, bytes);
-    readReturnSize(shared_from_this(), out, std::move(cb));
-  }
-
   void QuicStream::readSome(BytesOut out,
                             size_t bytes,
                             basic::Reader::ReadCallbackFunc cb) {

--- a/src/transport/tcp/tcp_connection.cpp
+++ b/src/transport/tcp/tcp_connection.cpp
@@ -172,14 +172,6 @@ namespace libp2p::transport {
         });
   }
 
-  void TcpConnection::read(BytesOut out,
-                           size_t bytes,
-                           TcpConnection::ReadCallbackFunc cb) {
-    ambigousSize(out, bytes);
-    TRACE("{} read {}", debug_str_, bytes);
-    readReturnSize(shared_from_this(), out, std::move(cb));
-  }
-
   void TcpConnection::readSome(BytesOut out,
                                size_t bytes,
                                TcpConnection::ReadCallbackFunc cb) {

--- a/test/acceptance/p2p/host/protocol/client_test_session.cpp
+++ b/test/acceptance/p2p/host/protocol/client_test_session.cpp
@@ -7,6 +7,7 @@
 
 #include <gtest/gtest.h>
 #include <boost/assert.hpp>
+#include <libp2p/basic/read_return_size.hpp>
 #include <libp2p/basic/write_return_size.hpp>
 #include <libp2p/crypto/random_generator/boost_generator.hpp>
 
@@ -53,16 +54,16 @@ namespace libp2p::protocol {
 
     read_buf_ = std::vector<uint8_t>(buffer_size_);
 
-    stream_->read(read_buf_,
-                  buffer_size_,
-                  [self = shared_from_this(),
-                   cb{std::move(cb)}](outcome::result<size_t> rr) mutable {
-                    if (!rr) {
-                      return cb(rr.error());
-                    }
-                    cb(std::move(self->read_buf_));
-                    return self->write(std::move(cb));
-                  });
+    readReturnSize(stream_,
+                   read_buf_,
+                   [self = shared_from_this(),
+                    cb{std::move(cb)}](outcome::result<size_t> rr) mutable {
+                     if (!rr) {
+                       return cb(rr.error());
+                     }
+                     cb(std::move(self->read_buf_));
+                     return self->write(std::move(cb));
+                   });
   }
 
 }  // namespace libp2p::protocol

--- a/test/acceptance/p2p/muxer.cpp
+++ b/test/acceptance/p2p/muxer.cpp
@@ -6,6 +6,7 @@
 
 #include <gtest/gtest.h>
 #include <cstdlib>
+#include <libp2p/basic/read_return_size.hpp>
 #include <libp2p/basic/scheduler/asio_scheduler_backend.hpp>
 #include <libp2p/basic/scheduler/scheduler_impl.hpp>
 #include <libp2p/basic/write_return_size.hpp>
@@ -255,19 +256,20 @@ struct Client : public std::enable_shared_from_this<Client> {
           auto readbuf = std::make_shared<std::vector<uint8_t>>();
           readbuf->resize(write);
 
-          stream->read(*readbuf,
-                       readbuf->size(),
-                       [round, streamId, write, buf, readbuf, stream, this](
-                           outcome::result<size_t> rread) {
-                         ASSERT_OUTCOME_SUCCESS(read, rread);
-                         this->println(streamId, " readSome ", read, " bytes");
-                         this->streamReads++;
+          readReturnSize(stream,
+                         *readbuf,
+                         [round, streamId, write, buf, readbuf, stream, this](
+                             outcome::result<size_t> rread) {
+                           ASSERT_OUTCOME_SUCCESS(read, rread);
+                           this->println(
+                               streamId, " readSome ", read, " bytes");
+                           this->streamReads++;
 
-                         ASSERT_EQ(write, read);
-                         ASSERT_EQ(*buf, *readbuf);
+                           ASSERT_EQ(write, read);
+                           ASSERT_EQ(*buf, *readbuf);
 
-                         this->onStream(streamId, round - 1, stream);
-                       });
+                           this->onStream(streamId, round - 1, stream);
+                         });
         });
   }
 

--- a/test/libp2p/connection/loopback_stream/loopback_stream_test.cpp
+++ b/test/libp2p/connection/loopback_stream/loopback_stream_test.cpp
@@ -6,6 +6,7 @@
 
 #include <gtest/gtest.h>
 #include <boost/asio/io_context.hpp>
+#include <libp2p/basic/read_return_size.hpp>
 #include <libp2p/basic/write_return_size.hpp>
 #include <libp2p/connection/loopback_stream.hpp>
 #include <libp2p/crypto/key_marshaller/key_marshaller_impl.hpp>
@@ -42,8 +43,10 @@ class LoopbackStreamTest : public testing::Test {
  * @then exactly the same data can be read from the stream
  */
 TEST_F(LoopbackStreamTest, Basic) {
-  ASSERT_OUTCOME_SUCCESS(hash, Multihash::create(libp2p::multi::sha256, kBuffer));
-  ASSERT_OUTCOME_SUCCESS(peer_id, PeerId::fromBase58(encodeBase58(hash.toBuffer())));
+  ASSERT_OUTCOME_SUCCESS(hash,
+                         Multihash::create(libp2p::multi::sha256, kBuffer));
+  ASSERT_OUTCOME_SUCCESS(peer_id,
+                         PeerId::fromBase58(encodeBase58(hash.toBuffer())));
 
   std::shared_ptr<libp2p::connection::Stream> stream =
       std::make_shared<LoopbackStream>(PeerInfo{peer_id, {}}, context);
@@ -55,9 +58,9 @@ TEST_F(LoopbackStreamTest, Basic) {
         auto read_buf = std::make_shared<Buffer>(kBufferSize, 0);
         ASSERT_EQ(read_buf->size(), kBufferSize);
         ASSERT_NE(*read_buf, buf);
-        stream->read(
+        libp2p::readReturnSize(
+            stream,
             *read_buf,
-            kBufferSize,
             [buf = read_buf, source_buf = buf, &all_executed](auto result) {
               ASSERT_OUTCOME_SUCCESS(bytes, result);
               ASSERT_EQ(bytes, kBufferSize);

--- a/test/libp2p/connection/security_conn/plaintext_connection_test.cpp
+++ b/test/libp2p/connection/security_conn/plaintext_connection_test.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <gtest/gtest.h>
+#include <libp2p/basic/read_return_size.hpp>
 #include <libp2p/basic/write_return_size.hpp>
 #include <libp2p/common/literals.hpp>
 #include <libp2p/security/plaintext/plaintext_connection.hpp>
@@ -124,7 +125,7 @@ TEST_F(PlaintextConnectionTest, Read) {
   const int size = 100;
   EXPECT_CALL_READ(*connection_).WILL_READ_SIZE(size);
   auto buf = std::make_shared<std::vector<uint8_t>>(size, 0);
-  secure_connection_->read(*buf, size, [size, buf](auto &&res) {
+  libp2p::readReturnSize(secure_connection_, *buf, [size, buf](auto &&res) {
     ASSERT_OUTCOME_SUCCESS(res);
     ASSERT_EQ(res.value(), size);
   });

--- a/test/libp2p/muxer/muxers_and_streams_test.cpp
+++ b/test/libp2p/muxer/muxers_and_streams_test.cpp
@@ -10,6 +10,7 @@
 #include <gtest/gtest.h>
 #include <boost/di/extension/scopes/shared.hpp>
 
+#include <libp2p/basic/read_return_size.hpp>
 #include <libp2p/basic/write_return_size.hpp>
 #include <libp2p/injector/host_injector.hpp>
 
@@ -173,8 +174,9 @@ namespace libp2p::regression {
         return behavior_(*this);
       }
       // clang-format off
-      stream->read(
-          *read_buf_, read_buf_->size(),
+      readReturnSize(
+          stream,
+          *read_buf_,
           [wptr = weak_from_this(), buf = read_buf_] (auto res) {
             auto self = wptr.lock();
             if (self) {  self->onRead(res); }

--- a/test/mock/libp2p/basic/read_writer_mock.hpp
+++ b/test/mock/libp2p/basic/read_writer_mock.hpp
@@ -12,7 +12,6 @@
 
 namespace libp2p::basic {
   struct ReadWriterMock : public ReadWriter {
-    MOCK_METHOD3(read, void(BytesOut, size_t, Reader::ReadCallbackFunc));
     MOCK_METHOD3(readSome, void(BytesOut, size_t, Reader::ReadCallbackFunc));
 
     MOCK_METHOD3(writeSome, void(BytesIn, size_t, Writer::WriteCallbackFunc));

--- a/test/mock/libp2p/basic/reader_mock.hpp
+++ b/test/mock/libp2p/basic/reader_mock.hpp
@@ -15,7 +15,6 @@ namespace libp2p::basic {
    public:
     ~ReaderMock() override = default;
 
-    MOCK_METHOD2(read, void(BytesOut, Reader::ReadCallbackFunc));
     MOCK_METHOD2(readSome, void(BytesOut, Reader::ReadCallbackFunc));
   };
 }  // namespace libp2p::basic

--- a/test/mock/libp2p/basic/readwritecloser_mock.hpp
+++ b/test/mock/libp2p/basic/readwritecloser_mock.hpp
@@ -19,7 +19,6 @@ namespace libp2p::basic {
 
     MOCK_METHOD0(close, outcome::result<void>(void));
 
-    MOCK_METHOD2(read, void(BytesOut, Reader::ReadCallbackFunc));
     MOCK_METHOD2(readSome, void(BytesOut, Reader::ReadCallbackFunc));
     MOCK_METHOD2(writeSome, void(BytesIn, Writer::WriteCallbackFunc));
   };

--- a/test/mock/libp2p/connection/capable_connection_mock.hpp
+++ b/test/mock/libp2p/connection/capable_connection_mock.hpp
@@ -8,6 +8,7 @@
 
 #include <gmock/gmock.h>
 
+#include <libp2p/basic/read_return_size.hpp>
 #include <libp2p/connection/capable_connection.hpp>
 
 namespace libp2p::connection {
@@ -82,7 +83,7 @@ namespace libp2p::connection {
     };
 
     void read(BytesOut in, size_t bytes, Reader::ReadCallbackFunc f) override {
-      return real_->read(in, bytes, f);
+      return readReturnSize(real_, in, f);
     };
 
     void readSome(BytesOut in,

--- a/test/mock/libp2p/connection/capable_connection_mock.hpp
+++ b/test/mock/libp2p/connection/capable_connection_mock.hpp
@@ -82,10 +82,6 @@ namespace libp2p::connection {
       return real_->remoteMultiaddr();
     };
 
-    void read(BytesOut in, size_t bytes, Reader::ReadCallbackFunc f) override {
-      return readReturnSize(real_, in, f);
-    };
-
     void readSome(BytesOut in,
                   size_t bytes,
                   Reader::ReadCallbackFunc f) override {

--- a/test/mock/libp2p/connection/capable_connection_mock.hpp
+++ b/test/mock/libp2p/connection/capable_connection_mock.hpp
@@ -32,7 +32,6 @@ namespace libp2p::connection {
 
     MOCK_CONST_METHOD0(isClosed, bool(void));
     MOCK_METHOD0(close, outcome::result<void>());
-    MOCK_METHOD3(read, void(BytesOut, size_t, Reader::ReadCallbackFunc));
     MOCK_METHOD3(readSome, void(BytesOut, size_t, Reader::ReadCallbackFunc));
     MOCK_METHOD3(writeSome, void(BytesIn, size_t, Writer::WriteCallbackFunc));
     MOCK_METHOD2(deferReadCallback,

--- a/test/mock/libp2p/connection/layer_connection_mock.hpp
+++ b/test/mock/libp2p/connection/layer_connection_mock.hpp
@@ -21,12 +21,6 @@ namespace libp2p::connection {
 
     MOCK_METHOD0(close, outcome::result<void>());
 
-    void read(BytesOut out,
-              size_t ambigous_size,
-              Reader::ReadCallbackFunc cb) override {
-      ASSERT_EQ(out.size(), ambigous_size);
-      readReturnSize(shared_from_this(), out, cb);
-    }
     MOCK_METHOD3(readSome, void(BytesOut, size_t, Reader::ReadCallbackFunc));
     MOCK_METHOD3(writeSome, void(BytesIn, size_t, Writer::WriteCallbackFunc));
     MOCK_METHOD2(deferReadCallback,

--- a/test/mock/libp2p/connection/secure_connection_mock.hpp
+++ b/test/mock/libp2p/connection/secure_connection_mock.hpp
@@ -19,7 +19,6 @@ namespace libp2p::connection {
 
     MOCK_METHOD0(close, outcome::result<void>(void));
 
-    MOCK_METHOD3(read, void(BytesOut, size_t, Reader::ReadCallbackFunc));
     MOCK_METHOD3(readSome, void(BytesOut, size_t, Reader::ReadCallbackFunc));
     MOCK_METHOD3(writeSome, void(BytesIn, size_t, Writer::WriteCallbackFunc));
 

--- a/test/mock/libp2p/connection/stream_mock.hpp
+++ b/test/mock/libp2p/connection/stream_mock.hpp
@@ -27,12 +27,6 @@ namespace libp2p::connection {
 
     MOCK_METHOD1(close, void(VoidResultHandlerFunc));
 
-    void read(BytesOut out,
-              size_t ambigous_size,
-              Reader::ReadCallbackFunc cb) override {
-      ASSERT_EQ(out.size(), ambigous_size);
-      readReturnSize(shared_from_this(), out, cb);
-    }
     MOCK_METHOD3(readSome, void(BytesOut, size_t, Reader::ReadCallbackFunc));
     MOCK_METHOD3(writeSome, void(BytesIn, size_t, Writer::WriteCallbackFunc));
 


### PR DESCRIPTION
Changed Reader::read with libp2p::readReturnSize and removed Reader::read interface and implementations.