### PR TITLE
Fix CMake compatibility issues with Hunter dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,15 @@
 cmake_minimum_required(VERSION 3.12)
 
+# Set CMake policies to handle compatibility with older dependencies
+if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.27")
+  cmake_policy(SET CMP0144 NEW)
+endif()
+
+# Set policy to handle older CMake requirements in dependencies
+if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.5")
+  cmake_policy(SET CMP0000 NEW)
+endif()
+
 if (PACKAGE_MANAGER)
   if(NOT PACKAGE_MANAGER MATCHES "^(hunter|vcpkg)$")
     message(FATAL_ERROR "PACKAGE_MANAGER must be set to 'hunter', 'vcpkg' or isn't set")
@@ -15,10 +25,6 @@ else ()
   endif ()
 endif ()
 message(STATUS "Selected package manager: ${PACKAGE_MANAGER}")
-
-if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.27")
-  cmake_policy(SET CMP0144 NEW)
-endif()
 
 find_program(CCACHE_FOUND ccache)
 if (CCACHE_FOUND)

--- a/cmake/Hunter/config.cmake
+++ b/cmake/Hunter/config.cmake
@@ -15,6 +15,44 @@
 #     CMAKE_ARGS "CMAKE_VARIABLE=value"
 # )
 
+# Fix for Protobuf CMake compatibility issue with modern CMake versions
+hunter_config(
+    Protobuf
+    VERSION 3.19.4-p0
+    CMAKE_ARGS
+      CMAKE_POLICY_VERSION_MINIMUM=3.5
+      protobuf_BUILD_TESTS=OFF
+      protobuf_BUILD_SHARED_LIBS=OFF
+    KEEP_PACKAGE_SOURCES
+)
+
+# Fix for c-ares CMake compatibility issue with modern CMake versions
+hunter_config(
+    c-ares
+    VERSION 1.14.0-p0
+    CMAKE_ARGS
+      CMAKE_POLICY_VERSION_MINIMUM=3.5
+    KEEP_PACKAGE_SOURCES
+)
+
+# Fix for yaml-cpp CMake compatibility issue with modern CMake versions
+hunter_config(
+    yaml-cpp
+    VERSION 0.6.2-0f9a586-p1
+    CMAKE_ARGS
+      CMAKE_POLICY_VERSION_MINIMUM=3.5
+    KEEP_PACKAGE_SOURCES
+)
+
+# Fix for Boost.DI CMake compatibility issue with modern CMake versions
+hunter_config(
+    Boost.DI
+    VERSION 1.1.0-p1
+    CMAKE_ARGS
+      CMAKE_POLICY_VERSION_MINIMUM=3.5
+    KEEP_PACKAGE_SOURCES
+)
+
 hunter_config(
     soralog
     VERSION 0.2.5


### PR DESCRIPTION

## Problem
The cpp-libp2p repository was failing to build on modern systems due to CMake compatibility issues with several Hunter package dependencies. These packages had outdated CMake configurations that required CMake < 3.5, but modern CMake versions have removed support for that compatibility level.

## Root Cause
Multiple Hunter packages were using outdated CMake configurations:
- Protobuf (3.19.4-p0)
- c-ares (1.14.0-p0) 
- yaml-cpp (0.6.2-0f9a586-p1)
- Boost.DI (1.1.0-p1)

These packages contained `cmake_minimum_required(VERSION < 3.5)` statements that are incompatible with modern CMake versions.

## Solution
Updated the Hunter configuration in `cmake/Hunter/config.cmake` to add custom configurations for each problematic dependency with the `CMAKE_POLICY_VERSION_MINIMUM=3.5` flag. This ensures compatibility with modern CMake versions while maintaining the existing package versions.

## Changes Made

### cmake/Hunter/config.cmake
- Added custom `hunter_config` for Protobuf with CMake compatibility flags
- Added custom `hunter_config` for c-ares with CMake compatibility flags  
- Added custom `hunter_config` for yaml-cpp with CMake compatibility flags
- Added custom `hunter_config` for Boost.DI with CMake compatibility flags

### CMakeLists.txt
- Added CMake policy settings to handle compatibility with older dependencies
- Set `CMP0144` and `CMP0000` policies for better compatibility

## Testing
- Clean build from scratch successful
- All dependencies resolved successfully
- Project compiles without errors
- All test targets build successfully
- Examples build successfully

## Before/After
**Before:** Build failed with errors like:
```
CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.
```

**After:** Build completes successfully with all targets compiled.

## Impact
- **Build Success:** Repository now builds successfully on modern systems
- **Developer Experience:** Developers can clone and build the project without CMake errors
- **CI/CD Compatibility:** Build systems with modern CMake versions will work correctly
- **No Breaking Changes:** Maintains existing functionality while fixing compatibility

## Related Issues
This fix addresses build failures that were preventing users from compiling the cpp-libp2p library on systems with current CMake versions.

## Notes
- No changes to the actual library code or functionality
- Only affects the build system configuration
- Maintains backward compatibility with existing Hunter package versions
- Follows Hunter package manager best practices for custom configurations
