### PR TITLE
Add move-friendly buffer accessors 

### DIFF
--- a/include/libp2p/multi/multihash.hpp
+++ b/include/libp2p/multi/multihash.hpp
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <memory>
 #include <utility>
 
 #include <libp2p/common/types.hpp>
@@ -85,7 +86,13 @@ namespace libp2p::multi {
     /**
      * @return a buffer with the multihash, including its type, length and hash
      */
-    const Buffer &toBuffer() const;
+    const Buffer &toBuffer() const &;
+
+    /**
+     * @return a buffer with the multihash, including its type, length and hash
+     *         (moved out of a temporary when unique)
+     */
+    Buffer toBuffer() &&;
 
     /**
      * @return Pre-calculated hash for std containers
@@ -129,7 +136,7 @@ namespace libp2p::multi {
 
     const Data &data() const;
 
-    std::shared_ptr<const Data> data_;
+    std::shared_ptr<Data> data_;
   };
 
 }  // namespace libp2p::multi

--- a/include/libp2p/multi/uvarint.hpp
+++ b/include/libp2p/multi/uvarint.hpp
@@ -55,7 +55,8 @@ namespace libp2p::multi {
     /// Disable to return span to inner data of temporary object
     BytesIn toBytes() const && = delete;
 
-    const std::vector<uint8_t> &toVector() const;
+    const std::vector<uint8_t> &toVector() const &;
+    std::vector<uint8_t> toVector() &&;
 
     /**
      * Assigns the varint to an unsigned integer, encoding the latter

--- a/include/libp2p/peer/peer_id.hpp
+++ b/include/libp2p/peer/peer_id.hpp
@@ -71,7 +71,8 @@ namespace libp2p::peer {
     /**
      * Creates a vector representation of PeerId.
      */
-    const std::vector<uint8_t> &toVector() const;
+    const std::vector<uint8_t> &toVector() const &;
+    std::vector<uint8_t> toVector() &&;
 
     /**
      * Get a SHA256 multihash of the peer's ID

--- a/src/multi/multihash.cpp
+++ b/src/multi/multihash.cpp
@@ -35,7 +35,7 @@ OUTCOME_CPP_DEFINE_CATEGORY(libp2p::multi, Multihash::Error, e) {
 namespace libp2p::multi {
 
   Multihash::Multihash(HashType type, BytesIn hash)
-      : data_(std::make_shared<const Data>(type, hash)) {}
+      : data_(std::make_shared<Data>(type, hash)) {}
 
   namespace {
     template <typename Buffer>
@@ -132,7 +132,16 @@ namespace libp2p::multi {
     return fmt::format("{:X}", data().bytes);
   }
 
-  const Bytes &Multihash::toBuffer() const {
+  const Bytes &Multihash::toBuffer() const & {
+    return data().bytes;
+  }
+
+  Bytes Multihash::toBuffer() && {
+    if (data_ && data_.use_count() == 1) {
+      auto data = std::move(data_);
+      data_ = nullptr;
+      return std::move(data->bytes);
+    }
     return data().bytes;
   }
 

--- a/src/multi/uvarint.cpp
+++ b/src/multi/uvarint.cpp
@@ -50,8 +50,12 @@ namespace libp2p::multi {
     return bytes_;
   }
 
-  const std::vector<uint8_t> &UVarint::toVector() const {
+  const std::vector<uint8_t> &UVarint::toVector() const & {
     return bytes_;
+  }
+
+  std::vector<uint8_t> UVarint::toVector() && {
+    return std::move(bytes_);
   }
 
   size_t UVarint::size() const {

--- a/src/peer/peer_id.cpp
+++ b/src/peer/peer_id.cpp
@@ -81,8 +81,12 @@ namespace libp2p::peer {
     return encodeBase58(hash_.toBuffer());
   }
 
-  const std::vector<uint8_t> &PeerId::toVector() const {
+  const std::vector<uint8_t> &PeerId::toVector() const & {
     return hash_.toBuffer();
+  }
+
+  std::vector<uint8_t> PeerId::toVector() && {
+    return std::move(hash_).toBuffer();
   }
 
   std::string PeerId::toHex() const {


### PR DESCRIPTION
## Overview
Implements the move-friendly accessor improvements requested in issue #95. Adds ref-qualified and rvalue overloads so temporaries can return buffers by move, eliminating unnecessary copies while keeping lvalue behavior unchanged.

## Problem
- `toBuffer`/`toVector` returned const references only, forcing an extra copy when called on temporaries.
- `Multihash` stored data in a const shared_ptr, blocking safe move-out even when uniquely owned.

## Solution
- Add const&/&& overloads for `toBuffer` and `toVector` on `Multihash`, `UVarint`, and `PeerId`.
- Allow `Multihash` to move out its byte buffer when uniquely owned; fall back to const& otherwise.
- Preserve existing API surface for lvalues; only move semantics change for rvalues.

## Key Changes
- `include/libp2p/multi/multihash.hpp` / `src/multi/multihash.cpp`: ref-qualified accessors; move-out path when `Data` is uniquely owned.
- `include/libp2p/multi/uvarint.hpp` / `src/multi/uvarint.cpp`: add rvalue `toVector` to move backing bytes from temporaries.
- `include/libp2p/peer/peer_id.hpp` / `src/peer/peer_id.cpp`: rvalue `toVector` delegates to moved `Multihash`.

Closes #95 