### PR TITLE
Fix overflow for permanent peer address TTL

### DIFF
--- a/src/peer/address_repository/inmem_address_repository.cpp
+++ b/src/peer/address_repository/inmem_address_repository.cpp
@@ -67,6 +67,14 @@ namespace libp2p::peer {
   Clock::time_point InmemAddressRepository::calculateExpirationTime(
       const Milliseconds &ttl) const {
     static const auto max_time = Clock::time_point::max();
+    // permanent TTLs use milliseconds::max() as a sentinel
+    // doing arithmetic with that value (e.g. now + ttl or max_time - ttl)
+    // can overflow chrono durations and cause undefined behaviour
+    // instead of touching the sentinel in time math, map it directly to
+    // time_point::max() to mean "never expires"
+    if (ttl == ttl::kPermanent) {
+      return max_time;
+    }
     const auto now = Clock::now();
     if (now >= max_time - ttl) {
       return max_time;

--- a/test/libp2p/peer/address_repository/inmem_address_repository_test.cpp
+++ b/test/libp2p/peer/address_repository/inmem_address_repository_test.cpp
@@ -186,3 +186,41 @@ TEST_F(InmemAddressRepository_Test, GetPeers) {
   auto s = db->getPeers();
   EXPECT_EQ(s.size(), 2);
 }
+
+/**
+ * @given address repository
+ * @when addAddresses/upsertAddresses with ttl::kPermanent
+ * @then addresses are stored and not evicted by collectGarbage
+ */
+TEST_F(InmemAddressRepository_Test, PermanentTtlNoOverflow) {
+  ASSERT_OUTCOME_SUCCESS(
+      db->addAddresses(p1, std::vector<Multiaddress>{ma1, ma2}, ttl::kPermanent));
+  ASSERT_OUTCOME_SUCCESS(
+      db->upsertAddresses(p2, std::vector<Multiaddress>{ma3}, ttl::kPermanent));
+
+  ASSERT_OUTCOME_SUCCESS(v1, db->getAddresses(p1));
+  ASSERT_OUTCOME_SUCCESS(v2, db->getAddresses(p2));
+  EXPECT_EQ(v1.size(), 2);
+  EXPECT_EQ(v2.size(), 1);
+
+  collectGarbage();
+  ASSERT_OUTCOME_SUCCESS(a1, db->getAddresses(p1));
+  ASSERT_OUTCOME_SUCCESS(a2, db->getAddresses(p2));
+  EXPECT_EQ(a1.size(), 2);
+  EXPECT_EQ(a2.size(), 1);
+  EXPECT_FALSE(a1.empty());
+  EXPECT_FALSE(a2.empty());
+}
+
+TEST_F(InmemAddressRepository_Test, LargeTtlClampedToMax) {
+  using namespace std::chrono;
+  auto large_ttl = milliseconds::max() - milliseconds(1);
+
+  ASSERT_OUTCOME_SUCCESS(
+      db->addAddresses(p1, std::vector<Multiaddress>{ma1}, large_ttl));
+
+  collectGarbage();
+
+  ASSERT_OUTCOME_SUCCESS(v, db->getAddresses(p1));
+  EXPECT_EQ(v.size(), 1);
+}


### PR DESCRIPTION
## Summary

Fix undefined behaviour in `InmemAddressRepository::calculateExpirationTime` when using `peer::ttl::kPermanent` by mapping permanent TTLs directly to `Clock::time_point::max()` and adding a regression test.

## Details

- **Issue**: `Signed overflow in InmemAddressRepository::upsertAddresses` (GitHub issue `#281`).
- Root cause: `calculateExpirationTime` used `max_time - ttl` and `now + ttl`; for `ttl::kPermanent == std::chrono::milliseconds::max()` both operations can overflow the underlying duration type and trigger UBSAN.
- Fix:
  - Special‑case `ttl::kPermanent` in `calculateExpirationTime` and immediately return `Clock::time_point::max()`.
  - Keep the previous logic (`now >= max_time - ttl ? max_time : now + ttl`) for all other TTL values.

## Tests

- New regression test: `InmemAddressRepository_Test.PermanentTtlNoOverflow` in `test/libp2p/peer/address_repository/inmem_address_repository_test.cpp`, which:
  - Inserts addresses with `ttl::kPermanent` via `addAddresses` and `upsertAddresses`.
  - Verifies they remain after `collectGarbage()` (permanent TTL addresses should never expire).
- Additional boundary test: `InmemAddressRepository_Test.LargeTtlClampedToMax`, which:
  - Uses a TTL very close to `Milliseconds::max()` and ensures the address remains after `collectGarbage()`.
- UBSAN build (`-DUBSAN=ON`) on macOS:
  - Before the fix, a dedicated repro test produced a `runtime error: signed integer overflow` in libc++ chrono with a frame in `InmemAddressRepository::calculateExpirationTime`.
  - After the fix, `PermanentTtlNoOverflow` passes under UBSAN with no reports.
- Non‑sanitizer build:
  - `ctest` in `build` (all 67 tests passed).

## Design note

An alternative would be to clamp large TTLs to `max_time` while still doing duration arithmetic. This change instead maps `ttl::kPermanent` directly to `time_point::max()` and leaves the existing logic for other TTLs unchanged, avoiding overflow in the sentinel case while keeping the fix minimal. A separate follow‑up issue proposes modeling permanence explicitly (e.g. a `Permanent | ExpiresAt(time_point)` style representation) to eliminate this class of bugs long‑term.

## Screenshot

The PR includes a UBSAN screenshot taken from `build-ubsan` showing:
- The command:
  - `UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1 ./test_bin/libp2p_inmem_address_repository_test --gtest_filter="*ReproduceKPermanentUBSAN*"` (before the fix).
- The `runtime error: signed integer overflow` message.
- The stack frame pointing to `InmemAddressRepository::calculateExpirationTime` and the repro test.

Screenshot:

<img width="3024" height="1506" alt="image" src="https://github.com/user-attachments/assets/1cf6ec9d-7671-4462-bdfb-308634a2eed5" />

Closes #281
