### PR TITLE
Removed `not` keyword in conditionals

### DIFF
--- a/example/01-echo/libp2p_echo_client.cpp
+++ b/example/01-echo/libp2p_echo_client.cpp
@@ -68,7 +68,7 @@ int main(int argc, char *argv[]) {
           // Additional logging config for application
           logger_config));
   auto r = logging_system->configure();
-  if (not r.message.empty()) {
+  if (!r.message.empty()) {
     (r.has_error ? std::cerr : std::cout) << r.message << std::endl;
   }
   if (r.has_error) {

--- a/example/01-echo/libp2p_echo_server.cpp
+++ b/example/01-echo/libp2p_echo_server.cpp
@@ -90,7 +90,7 @@ int main(int argc, char **argv) {
           // Additional logging config for application
           logger_config));
   auto r = logging_system->configure();
-  if (not r.message.empty()) {
+  if (!r.message.empty()) {
     (r.has_error ? std::cerr : std::cout) << r.message << std::endl;
   }
   if (r.has_error) {

--- a/example/02-kademlia/rendezvous_chat.cpp
+++ b/example/02-kademlia/rendezvous_chat.cpp
@@ -49,7 +49,7 @@ class Session : public std::enable_shared_from_this<Session> {
     stream_->readSome(
         *incoming_,
         [self = shared_from_this()](outcome::result<size_t> result) {
-          if (not result) {
+          if (!result) {
             self->close();
             std::cout << self->stream_->remotePeerId().value().toBase58()
                       << " - closed at reading" << std::endl;
@@ -74,7 +74,7 @@ class Session : public std::enable_shared_from_this<Session> {
         stream_,
         *buffer,
         [self = shared_from_this(), buffer](outcome::result<void> result) {
-          if (not result) {
+          if (!result) {
             self->close();
             std::cout << self->stream_->remotePeerId().value().toBase58()
                       << " - closed at writting" << std::endl;
@@ -128,7 +128,7 @@ void handleIncomingStream(libp2p::StreamAndProtocol stream_and_protocol) {
 }
 
 void handleOutgoingStream(libp2p::StreamAndProtocolOrError stream_res) {
-  if (not stream_res) {
+  if (!stream_res) {
     fmt::println(
         std::cerr, " ! outgoing connection failed: {}", stream_res.error());
     return;
@@ -178,7 +178,7 @@ int main(int argc, char *argv[]) {
           // Additional logging config for application
           logger_config));
   auto r = logging_system->configure();
-  if (not r.message.empty()) {
+  if (!r.message.empty()) {
     (r.has_error ? std::cerr : std::cout) << r.message << std::endl;
   }
   if (r.has_error) {
@@ -295,7 +295,7 @@ int main(int argc, char *argv[]) {
             scheduler.schedule(std::function{find_providers},
                                kademlia_config.randomWalk.interval);
 
-            if (not res) {
+            if (!res) {
               fmt::println(std::cerr, "Cannot find providers: {}", res.error());
               return;
             }
@@ -317,7 +317,7 @@ int main(int argc, char *argv[]) {
 
     post(*io, [&] {
       auto listen = host->listen(ma);
-      if (not listen) {
+      if (!listen) {
         fmt::println(std::cerr,
                      "Cannot listen address {}. Error: {}",
                      ma.getStringAddress(),

--- a/example/02-kademlia/rendezvous_chat.cpp
+++ b/example/02-kademlia/rendezvous_chat.cpp
@@ -309,7 +309,7 @@ int main(int argc, char *argv[]) {
 
     std::function<void()> provide = [&, content_id] {
       [[maybe_unused]] auto res =
-          kademlia->provide(content_id, not kademlia_config.passiveMode);
+          kademlia->provide(content_id, !kademlia_config.passiveMode);
 
       scheduler.schedule(std::function{provide},
                          kademlia_config.randomWalk.interval);

--- a/example/03-gossip/gossip_chat_example.cpp
+++ b/example/03-gossip/gossip_chat_example.cpp
@@ -67,7 +67,7 @@ int main(int argc, char *argv[]) {
           // Additional logging config for application
           logger_config));
   auto r = logging_system->configure();
-  if (not r.message.empty()) {
+  if (!r.message.empty()) {
     (r.has_error ? std::cerr : std::cout) << r.message << std::endl;
   }
   if (r.has_error) {

--- a/example/04-dnstxt/ares_resolver.cpp
+++ b/example/04-dnstxt/ares_resolver.cpp
@@ -38,7 +38,7 @@ int main(int argc, char *argv[]) {
           // Additional logging config for application
           logger_config));
   auto r = logging_system->configure();
-  if (not r.message.empty()) {
+  if (!r.message.empty()) {
     (r.has_error ? std::cerr : std::cout) << r.message << std::endl;
   }
   if (r.has_error) {

--- a/include/libp2p/basic/read.hpp
+++ b/include/libp2p/basic/read.hpp
@@ -36,7 +36,7 @@ namespace libp2p {
           }
           // read remaining bytes
           auto reader = weak.lock();
-          if (not reader) {
+          if (!reader) {
             return cb(make_error_code(boost::asio::error::operation_aborted));
           }
           read(reader, out.subspan(n), std::move(cb));

--- a/include/libp2p/basic/scheduler/manual_scheduler_backend.hpp
+++ b/include/libp2p/basic/scheduler/manual_scheduler_backend.hpp
@@ -57,11 +57,11 @@ namespace libp2p::basic {
      * @return true if no more events scheduled
      */
     bool empty() const {
-      return deferred_callbacks_.empty() and not timer_expires_;
+      return deferred_callbacks_.empty() and !timer_expires_;
     }
 
     void run() {
-      while (not empty()) {
+      while (!empty()) {
         shiftToTimer();
       }
     }

--- a/include/libp2p/basic/write.hpp
+++ b/include/libp2p/basic/write.hpp
@@ -36,7 +36,7 @@ namespace libp2p {
           }
           // write remaining bytes
           auto writer = weak.lock();
-          if (not writer) {
+          if (!writer) {
             return cb(make_error_code(boost::asio::error::operation_aborted));
           }
           write(writer, in.subspan(n), std::move(cb));

--- a/include/libp2p/common/outcome_macro.hpp
+++ b/include/libp2p/common/outcome_macro.hpp
@@ -11,7 +11,7 @@
 #define _IF_ERROR_CB_RETURN(tmp, r) \
   ({                                \
     auto &&_r = r;                  \
-    if (not _r.has_value()) {       \
+    if (!_r.has_value()) {       \
       return cb(_r.error());        \
     }                               \
     _r.value();                     \

--- a/include/libp2p/common/outcome_macro.hpp
+++ b/include/libp2p/common/outcome_macro.hpp
@@ -11,7 +11,7 @@
 #define _IF_ERROR_CB_RETURN(tmp, r) \
   ({                                \
     auto &&_r = r;                  \
-    if (!_r.has_value()) {       \
+    if (!_r.has_value()) {          \
       return cb(_r.error());        \
     }                               \
     _r.value();                     \

--- a/include/libp2p/injector/network_injector.hpp
+++ b/include/libp2p/injector/network_injector.hpp
@@ -160,7 +160,7 @@ namespace libp2p::injector {
    */
   inline auto useWssPem(std::string_view pem) {
     layer::WssCertificate cert;
-    if (not pem.empty()) {
+    if (!pem.empty()) {
       if (auto cert_res = layer::WssCertificate::make(pem)) {
         cert = std::move(cert_res.value());
       } else {

--- a/include/libp2p/log/sublogger.hpp
+++ b/include/libp2p/log/sublogger.hpp
@@ -87,7 +87,7 @@ namespace libp2p::log {
     template <typename T>
     auto makePrefix(std::string_view prefix, T instance) {
       if constexpr (std::is_pointer_v<T>
-                    and not std::is_same_v<T, const char *>) {
+                    and !std::is_same_v<T, const char *>) {
         auto ptr_as_int = reinterpret_cast<std::intptr_t>(instance);  // NOLINT
         return fmt::format("{}({:x}): ", prefix, ptr_as_int);
       } else if constexpr (std::is_integral_v<T> and sizeof(T) > 1) {

--- a/include/libp2p/log/sublogger.hpp
+++ b/include/libp2p/log/sublogger.hpp
@@ -86,8 +86,7 @@ namespace libp2p::log {
    private:
     template <typename T>
     auto makePrefix(std::string_view prefix, T instance) {
-      if constexpr (std::is_pointer_v<T>
-                    and !std::is_same_v<T, const char *>) {
+      if constexpr (std::is_pointer_v<T> and !std::is_same_v<T, const char *>) {
         auto ptr_as_int = reinterpret_cast<std::intptr_t>(instance);  // NOLINT
         return fmt::format("{}({:x}): ", prefix, ptr_as_int);
       } else if constexpr (std::is_integral_v<T> and sizeof(T) > 1) {

--- a/include/libp2p/transport/tcp/tcp_util.hpp
+++ b/include/libp2p/transport/tcp/tcp_util.hpp
@@ -72,7 +72,7 @@ namespace libp2p::transport::detail {
     template <typename T>
     outcome::result<T> as(bool udp) const {
       auto ip = std::get_if<boost::asio::ip::address>(&this->ip);
-      if (this->udp != udp or not ip) {
+      if (this->udp != udp or !ip) {
         return std::errc::protocol_not_supported;
       }
       return T{*ip, port};

--- a/include/libp2p/transport/tcp/tcp_util.hpp
+++ b/include/libp2p/transport/tcp/tcp_util.hpp
@@ -128,7 +128,7 @@ namespace libp2p::transport::detail {
     auto v = ma.getProtocolsWithValues();
     auto it = v.begin();
     OUTCOME_TRY(addr, readTcpOrUdp(it, v.end()));
-    if (not addr.udp) {
+    if (!addr.udp) {
       return std::errc::protocol_not_supported;
     }
     if (it == v.end()) {
@@ -185,7 +185,7 @@ namespace libp2p::transport::detail {
       const boost::asio::ip::tcp::endpoint &endpoint,
       const ProtoAddrVec &layers) {
     OUTCOME_TRY(s, toMultiaddr(endpoint));
-    if (not layers.empty()) {
+    if (!layers.empty()) {
       auto &protocol = layers.at(0).first.code;
       if (protocol == P::WS) {
         s += "/ws";

--- a/src/basic/scheduler/manual_scheduler_backend.cpp
+++ b/src/basic/scheduler/manual_scheduler_backend.cpp
@@ -36,7 +36,7 @@ namespace libp2p::basic {
   }
 
   void ManualSchedulerBackend::callDeferred() {
-    while (not deferred_callbacks_.empty()) {
+    while (!deferred_callbacks_.empty()) {
       auto cb = std::move(deferred_callbacks_.front());
       deferred_callbacks_.pop_front();
       cb();

--- a/src/basic/scheduler/scheduler_impl.cpp
+++ b/src/basic/scheduler/scheduler_impl.cpp
@@ -86,7 +86,7 @@ namespace libp2p::basic {
 
   void SchedulerImpl::pulse() {
     callReady(Time::zero());
-    while (not callbacks_.empty()) {
+    while (!callbacks_.empty()) {
       auto now = backend_->now();
       if (callReady(now) != 0) {
         continue;
@@ -103,7 +103,7 @@ namespace libp2p::basic {
 
   size_t SchedulerImpl::callReady(Time now) {
     size_t removed = 0;
-    while (not callbacks_.empty() and callbacks_.begin()->first <= now) {
+    while (!callbacks_.empty() and callbacks_.begin()->first <= now) {
       auto node = callbacks_.extract(callbacks_.begin());
       ++removed;
       if (auto cb = std::get_if<Callback>(&node.mapped())) {

--- a/src/basic/scheduler/scheduler_impl.cpp
+++ b/src/basic/scheduler/scheduler_impl.cpp
@@ -20,7 +20,7 @@ namespace libp2p::basic {
       Callback &&cb,
       std::chrono::milliseconds delay_from_now,
       bool make_handle) {
-    if (not cb) {
+    if (!cb) {
       throw std::logic_error{"SchedulerImpl::scheduleImpl empty cb arg"};
     }
 
@@ -28,11 +28,11 @@ namespace libp2p::basic {
     if (Time::zero() < delay_from_now) {
       abs = backend_->now() + delay_from_now;
     }
-    if (not make_handle) {
+    if (!make_handle) {
       backend_->post(
           [weak_self{weak_from_this()}, cb{std::move(cb)}, abs]() mutable {
             auto self = weak_self.lock();
-            if (not self) {
+            if (!self) {
               return;
             }
             self->callbacks_.emplace(abs, std::move(cb));
@@ -45,7 +45,7 @@ namespace libp2p::basic {
     backend_->post(
         [weak_self{weak_from_this()}, abs, cancel{std::move(cancel)}] {
           auto self = weak_self.lock();
-          if (not self) {
+          if (!self) {
             return;
           }
           if (cancel->cancelled.test()) {
@@ -57,26 +57,26 @@ namespace libp2p::basic {
     return cancelFn(
         [weak_self{weak_from_this()}, weak_cancel{std::move(weak_cancel)}] {
           auto cancel = weak_cancel.lock();
-          if (not cancel) {
+          if (!cancel) {
             return;
           }
           if (cancel->cancelled.test_and_set()) {
             return;
           }
           auto self = weak_self.lock();
-          if (not self) {
+          if (!self) {
             return;
           }
           self->backend_->post([weak_self, weak_cancel] {
             auto cancel = weak_cancel.lock();
-            if (not cancel) {
+            if (!cancel) {
               return;
             }
-            if (not cancel->it) {
+            if (!cancel->it) {
               return;
             }
             auto self = weak_self.lock();
-            if (not self) {
+            if (!self) {
               return;
             }
             self->callbacks_.erase(*cancel->it);

--- a/src/connection/loopback_stream.cpp
+++ b/src/connection/loopback_stream.cpp
@@ -19,7 +19,7 @@ namespace libp2p::connection {
       boost::asio::post(
           ctx,
           [wptr{std::move(wptr)}, cb{std::move(cb)}, arg{std::move(arg)}]() {
-            if (not wptr.expired()) {
+            if (!wptr.expired()) {
               cb(arg);
             }
           });
@@ -154,7 +154,7 @@ namespace libp2p::connection {
     }
 
     // subscribe to new data updates
-    if (not data_notifyee_) {
+    if (!data_notifyee_) {
       data_notifyee_ = std::move(read_lambda);
     }
   }

--- a/src/crypto/hmac_provider/hmac_provider_ctr_impl.cpp
+++ b/src/crypto/hmac_provider/hmac_provider_ctr_impl.cpp
@@ -52,7 +52,7 @@ namespace libp2p::crypto::hmac {
   }
 
   outcome::result<void> HmacProviderCtrImpl::write(BytesIn data) {
-    if (not initialized_) {
+    if (!initialized_) {
       return HmacProviderError::FAILED_INITIALIZE_CONTEXT;
     }
     if (1 != HMAC_Update(hmac_ctx_, data.data(), data.size())) {
@@ -62,7 +62,7 @@ namespace libp2p::crypto::hmac {
   }
 
   outcome::result<void> HmacProviderCtrImpl::digestOut(BytesOut out) const {
-    if (not initialized_) {
+    if (!initialized_) {
       return HmacProviderError::FAILED_INITIALIZE_CONTEXT;
     }
     if (out.size() != digestSize()) {

--- a/src/crypto/sha/sha1.cpp
+++ b/src/crypto/sha/sha1.cpp
@@ -19,7 +19,7 @@ namespace libp2p::crypto {
   }
 
   outcome::result<void> Sha1::write(BytesIn data) {
-    if (not initialized_) {
+    if (!initialized_) {
       return HmacProviderError::FAILED_INITIALIZE_CONTEXT;
     }
     if (1 != SHA1_Update(&ctx_, data.data(), data.size())) {
@@ -29,7 +29,7 @@ namespace libp2p::crypto {
   }
 
   outcome::result<void> Sha1::digestOut(BytesOut out) const {
-    if (not initialized_) {
+    if (!initialized_) {
       return HmacProviderError::FAILED_INITIALIZE_CONTEXT;
     }
     if (out.size() != digestSize()) {

--- a/src/crypto/sha/sha256.cpp
+++ b/src/crypto/sha/sha256.cpp
@@ -21,7 +21,7 @@ namespace libp2p::crypto {
   }
 
   outcome::result<void> Sha256::write(BytesIn data) {
-    if (not initialized_) {
+    if (!initialized_) {
       return HmacProviderError::FAILED_INITIALIZE_CONTEXT;
     }
     if (1 != SHA256_Update(&ctx_, data.data(), data.size())) {
@@ -31,7 +31,7 @@ namespace libp2p::crypto {
   }
 
   outcome::result<void> Sha256::digestOut(BytesOut out) const {
-    if (not initialized_) {
+    if (!initialized_) {
       return HmacProviderError::FAILED_INITIALIZE_CONTEXT;
     }
     if (out.size() != digestSize()) {

--- a/src/crypto/sha/sha512.cpp
+++ b/src/crypto/sha/sha512.cpp
@@ -21,7 +21,7 @@ namespace libp2p::crypto {
   }
 
   outcome::result<void> Sha512::write(BytesIn data) {
-    if (not initialized_) {
+    if (!initialized_) {
       return HmacProviderError::FAILED_INITIALIZE_CONTEXT;
     }
     if (1 != SHA512_Update(&ctx_, data.data(), data.size())) {
@@ -31,7 +31,7 @@ namespace libp2p::crypto {
   }
 
   outcome::result<void> Sha512::digestOut(BytesOut out) const {
-    if (not initialized_) {
+    if (!initialized_) {
       return HmacProviderError::FAILED_INITIALIZE_CONTEXT;
     }
     if (out.size() != digestSize()) {

--- a/src/host/basic_host/basic_host.cpp
+++ b/src/host/basic_host/basic_host.cpp
@@ -72,7 +72,7 @@ namespace libp2p::host {
           }
         }
       }
-      if (not is_good_addr) {
+      if (!is_good_addr) {
         i = unique_addresses.erase(i);
       } else {
         ++i;

--- a/src/layer/websocket/ws_connection.cpp
+++ b/src/layer/websocket/ws_connection.cpp
@@ -39,7 +39,7 @@ namespace libp2p::connection {
   }
 
   void WsConnection::stop() {
-    if (not started_) {
+    if (!started_) {
       log_->error("already stopped (double stop)");
       return;
     }

--- a/src/layer/websocket/wss_adaptor.cpp
+++ b/src/layer/websocket/wss_adaptor.cpp
@@ -43,7 +43,7 @@ namespace libp2p::layer {
   void WssAdaptor::upgradeInbound(
       std::shared_ptr<connection::LayerConnection> conn,
       LayerAdaptor::LayerConnCallbackFunc cb) const {
-    if (not server_certificate_.context) {
+    if (!server_certificate_.context) {
       return cb(std::errc::address_family_not_supported);
     }
     auto ssl = std::make_shared<connection::SslConnection>(

--- a/src/multi/converters/converter_utils.cpp
+++ b/src/multi/converters/converter_utils.cpp
@@ -191,7 +191,7 @@ namespace libp2p::multi::converters {
     };
     auto uvar = [&]() -> outcome::result<uint64_t> {
       auto var = UVarint::create(bytes);
-      if (not var) {
+      if (!var) {
         return ConversionError::INVALID_ADDRESS;
       }
       bytes = bytes.subspan(var->size());

--- a/src/multi/converters/converter_utils.cpp
+++ b/src/multi/converters/converter_utils.cpp
@@ -59,7 +59,7 @@ inline std::string percentDecode(std::string_view str) {
     return std::nullopt;
   };
   std::string out;
-  while (not str.empty()) {
+  while (!str.empty()) {
     if (str[0] == '%' and str.size() >= 3) {
       auto x1 = f(str[1]), x2 = f(str[2]);
       if (x1 and x2) {
@@ -202,7 +202,7 @@ namespace libp2p::multi::converters {
       return read(n);
     };
     std::string results;
-    while (not bytes.empty()) {
+    while (!bytes.empty()) {
       OUTCOME_TRY(protocol_num, uvar());
       const Protocol *protocol =
           ProtocolList::get(static_cast<Protocol::Code>(protocol_num));

--- a/src/multi/multiaddress.cpp
+++ b/src/multi/multiaddress.cpp
@@ -107,7 +107,7 @@ namespace libp2p::multi {
     }
 
     std::string proto_str = '/' + std::string(p->name);
-    if (not address.empty()) {
+    if (!address.empty()) {
       proto_str += '/';
       proto_str += address;
     }

--- a/src/muxer/mplex/mplex_stream.cpp
+++ b/src/muxer/mplex/mplex_stream.cpp
@@ -120,7 +120,7 @@ namespace libp2p::connection {
           std::lock_guard<std::mutex> lock(self->write_queue_mutex_);
           // check if new write messages were received while stream was writing
           // and propagate these messages
-          if (not self->write_queue_.empty()) {
+          if (!self->write_queue_.empty()) {
             auto [in, cb] = self->write_queue_.front();
             self->write_queue_.pop_front();
             self->writeSome(in, cb);

--- a/src/muxer/yamux/yamuxed_connection.cpp
+++ b/src/muxer/yamux/yamuxed_connection.cpp
@@ -660,7 +660,7 @@ namespace libp2p::connection {
 
     is_writing_ = false;
 
-    if (not write_queue_.empty()) {
+    if (!write_queue_.empty()) {
       auto next_packet = std::move(write_queue_.front());
       write_queue_.pop_front();
       doWrite(std::move(next_packet));
@@ -723,10 +723,10 @@ namespace libp2p::connection {
     cleanup_handle_ = scheduler_->scheduleWithHandle(
         [weak_self{weak_from_this()}] {
           auto self = weak_self.lock();
-          if (not self) {
+          if (!self) {
             return;
           }
-          if (not self->started_) {
+          if (!self->started_) {
             return;
           }
           std::vector<StreamId> abandoned;
@@ -751,14 +751,14 @@ namespace libp2p::connection {
     ping_handle_ = scheduler_->scheduleWithHandle(
         [weak_self{weak_from_this()}] {
           auto self = weak_self.lock();
-          if (not self) {
+          if (!self) {
             return;
           }
-          if (not self->started_) {
+          if (!self->started_) {
             return;
           }
           // dont send pings if something is being written
-          if (not self->is_writing_) {
+          if (!self->is_writing_) {
             self->enqueue(pingOutMsg(++self->ping_counter_));
             SL_TRACE(log(), "written ping message #{}", self->ping_counter_);
           }

--- a/src/network/cares/cares.cpp
+++ b/src/network/cares/cares.cpp
@@ -198,7 +198,7 @@ namespace libp2p::network::c_ares {
   void Ares::waitAresChannel(::ares_channel channel) {
     while (true) {
       struct timeval *tvp{nullptr};  // NOLINT
-      struct timeval tv {};
+      struct timeval tv{};
       fd_set read_fds;
       fd_set write_fds;
       int nfds{0};  // NOLINT

--- a/src/network/cares/cares.cpp
+++ b/src/network/cares/cares.cpp
@@ -73,7 +73,7 @@ namespace libp2p::network::c_ares {
   Ares::Ares() {
     bool expected{false};
     bool first_init = initialized_.compare_exchange_strong(expected, true);
-    if (not first_init) {
+    if (!first_init) {
       // atomic change failed, thus it was already initialized
       SL_DEBUG(log(), "C-ares library got initialized more than once");
     } else if (auto status = ::ares_library_init(ARES_LIB_INIT_ALL);
@@ -98,7 +98,7 @@ namespace libp2p::network::c_ares {
       const std::string &uri,
       const std::weak_ptr<boost::asio::io_context> &io_context,
       Ares::TxtCallback callback) {
-    if (not initialized_.load()) {
+    if (!initialized_.load()) {
       SL_DEBUG(
           log(),
           "Unable to execute DNS TXT request to {} due to c-ares library is "

--- a/src/network/impl/connection_manager_impl.cpp
+++ b/src/network/impl/connection_manager_impl.cpp
@@ -26,7 +26,7 @@ namespace libp2p::network {
     std::vector<ConnectionSPtr> out;
     out.reserve(it->second.size());
     for (const auto &conn : it->second) {
-      if (not conn->isClosed()) {
+      if (!conn->isClosed()) {
         out.emplace_back(conn);
       }
     }
@@ -72,7 +72,7 @@ namespace libp2p::network {
     size_t total_connections = 0;
     for (const auto &entry : connections_) {
       for (const auto &conn : entry.second) {
-        if (not conn->isClosed()) {
+        if (!conn->isClosed()) {
           ++total_connections;
         }
       }
@@ -81,7 +81,7 @@ namespace libp2p::network {
 
     for (const auto &entry : connections_) {
       for (const auto &conn : entry.second) {
-        if (not conn->isClosed()) {
+        if (!conn->isClosed()) {
           out.emplace_back(conn);
         }
       }

--- a/src/network/impl/dialer_impl.cpp
+++ b/src/network/impl/dialer_impl.cpp
@@ -68,7 +68,7 @@ namespace libp2p::network {
     auto &&ctx = ctx_found->second;
 
     if (ctx.addr_queue.empty()) {
-      if (not ctx.dialled) {
+      if (!ctx.dialled) {
         completeDial(peer_id, std::errc::address_family_not_supported);
         return;
       }

--- a/src/network/impl/dialer_impl.cpp
+++ b/src/network/impl/dialer_impl.cpp
@@ -94,7 +94,7 @@ namespace libp2p::network {
                   self->log_,
                   "State inconsistency - uninteresting dial result for peer {}",
                   peer_id.toBase58());
-              if (result.has_value() and not result.value()->isClosed()) {
+              if (result.has_value() and !result.value()->isClosed()) {
                 auto close_res = result.value()->close();
                 BOOST_ASSERT(close_res);
               }
@@ -119,7 +119,7 @@ namespace libp2p::network {
           }
           // closing the connection when dialer and connection requester
           // callback no more exist
-          if (result.has_value() and not result.value()->isClosed()) {
+          if (result.has_value() and !result.value()->isClosed()) {
             auto close_res = result.value()->close();
             BOOST_ASSERT(close_res);
           }

--- a/src/network/impl/dnsaddr_resolver_impl.cpp
+++ b/src/network/impl/dnsaddr_resolver_impl.cpp
@@ -52,7 +52,7 @@ namespace libp2p::network {
           std::all_of(lines.begin(), lines.end(), [](const std::string &line) {
             return 0 == line.rfind("dnsaddr=", 0);
           });
-      if (not prefixed) {
+      if (!prefixed) {
         cb(Error::MALFORMED_RESPONSE);
         return;
       }
@@ -80,7 +80,7 @@ namespace libp2p::network {
 
   outcome::result<std::string> DnsaddrResolverImpl::dnsaddrUriFromMultiaddr(
       const multi::Multiaddress &address) {
-    if (not address.hasProtocol(kDnsaddr)) {
+    if (!address.hasProtocol(kDnsaddr)) {
       return Error::INVALID_DNSADDR;
     }
     OUTCOME_TRY(hostname, address.getFirstValueForProtocol(kDnsaddr));

--- a/src/peer/address_repository/inmem_address_repository.cpp
+++ b/src/peer/address_repository/inmem_address_repository.cpp
@@ -18,7 +18,7 @@ namespace libp2p::peer {
 
   void InmemAddressRepository::bootstrap(const multi::Multiaddress &ma,
                                          std::function<BootstrapCallback> cb) {
-    if (not isNewDnsAddr(ma)) {
+    if (!isNewDnsAddr(ma)) {
       return;  // just skip silently circular references among dnsaddrs
     }
     dnsaddr_resolver_->load(
@@ -141,10 +141,10 @@ namespace libp2p::peer {
       return;
     }
     auto &peer = peer_it->second;
-    if (not peer.expires.contains(addr)) {
+    if (!peer.expires.contains(addr)) {
       return;
     }
-    if (not peer.eraseOrder(addr)) {
+    if (!peer.eraseOrder(addr)) {
       return;
     }
     peer.order.emplace_back(addr);

--- a/src/protocol/echo/client_echo_session.cpp
+++ b/src/protocol/echo/client_echo_session.cpp
@@ -75,7 +75,7 @@ namespace libp2p::protocol {
       if (ec_) {
         then(*ec_);
       } else {
-        if (not std::equal(
+        if (!std::equal(
                 recv_buf_.begin(), recv_buf_.end(), buf_.begin(), buf_.end())) {
           log::createLogger("Echo")->error(
               "ClientEchoSession: send and receive buffers mismatch");

--- a/src/protocol/gossip/impl/gossip_core.cpp
+++ b/src/protocol/gossip/impl/gossip_core.cpp
@@ -379,7 +379,7 @@ namespace libp2p::protocol::gossip {
     heartbeat_timer_ = scheduler_->scheduleWithHandle(
         [weak_self{weak_from_this()}] {
           auto self = weak_self.lock();
-          if (not self) {
+          if (!self) {
             return;
           }
           self->onHeartbeat();

--- a/src/protocol/gossip/impl/stream.cpp
+++ b/src/protocol/gossip/impl/stream.cpp
@@ -161,7 +161,7 @@ namespace libp2p::protocol::gossip {
         *buffer,
         [weak_self{weak_from_this()}, buffer](outcome::result<void> result) {
           auto self = weak_self.lock();
-          if (not self) {
+          if (!self) {
             return;
           }
           self->onMessageWritten(result);

--- a/src/protocol/gossip/impl/topic_subscriptions.cpp
+++ b/src/protocol/gossip/impl/topic_subscriptions.cpp
@@ -41,7 +41,7 @@ namespace libp2p::protocol::gossip {
         log_(log) {}
 
   bool TopicSubscriptions::empty() const {
-    return (not self_subscribed_)
+    return (!self_subscribed_)
         && (fanout_period_ends_ == std::chrono::milliseconds::zero())
         && subscribed_peers_.empty() && mesh_peers_.empty();
   }

--- a/src/protocol/kademlia/impl/add_provider_executor.cpp
+++ b/src/protocol/kademlia/impl/add_provider_executor.cpp
@@ -96,7 +96,7 @@ namespace libp2p::protocol::kademlia {
 
     auto self_peer_id = host_->getId();
 
-    while (started_ and not done_ and not queue_.empty()
+    while (started_ and !done_ and !queue_.empty()
            and requests_in_progress_ < config_.requestConcurency
            and requests_succeed_ < config_.closerPeerCount) {
       auto peer_id = *queue_.top();

--- a/src/protocol/kademlia/impl/add_provider_executor.cpp
+++ b/src/protocol/kademlia/impl/add_provider_executor.cpp
@@ -82,7 +82,7 @@ namespace libp2p::protocol::kademlia {
 
   void AddProviderExecutor::done() {
     bool x = false;
-    if (not done_.compare_exchange_strong(x, true)) {
+    if (!done_.compare_exchange_strong(x, true)) {
       return;
     }
 
@@ -158,7 +158,7 @@ namespace libp2p::protocol::kademlia {
   }
 
   void AddProviderExecutor::onConnected(StreamAndProtocolOrError stream_res) {
-    if (not stream_res) {
+    if (!stream_res) {
       --requests_in_progress_;
 
       log_.debug("cannot connect to peer: {}; done {}, active {}, in queue {}",

--- a/src/protocol/kademlia/impl/content_routing_table_impl.cpp
+++ b/src/protocol/kademlia/impl/content_routing_table_impl.cpp
@@ -91,7 +91,7 @@ namespace libp2p::protocol::kademlia {
     cleanup_timer_ = scheduler_.scheduleWithHandle(
         [weak_self{weak_from_this()}] {
           auto self = weak_self.lock();
-          if (not self) {
+          if (!self) {
             return;
           }
           self->onCleanupTimer();

--- a/src/protocol/kademlia/impl/find_peer_executor.cpp
+++ b/src/protocol/kademlia/impl/find_peer_executor.cpp
@@ -63,7 +63,7 @@ namespace libp2p::protocol::kademlia {
     serialized_request_ = std::make_shared<std::vector<uint8_t>>();
 
     boost::optional<peer::PeerInfo> self_announce;
-    if (not config_.passiveMode) {
+    if (!config_.passiveMode) {
       self_announce = host_->getPeerInfo();
     }
 
@@ -91,7 +91,7 @@ namespace libp2p::protocol::kademlia {
 
   void FindPeerExecutor::done(outcome::result<PeerInfo> result) {
     bool x = false;
-    if (not done_.compare_exchange_strong(x, true)) {
+    if (!done_.compare_exchange_strong(x, true)) {
       return;
     }
     if (result.has_value()) {
@@ -169,7 +169,7 @@ namespace libp2p::protocol::kademlia {
   }
 
   void FindPeerExecutor::onConnected(StreamAndProtocolOrError stream_res) {
-    if (not stream_res) {
+    if (!stream_res) {
       --requests_in_progress_;
 
       log_.debug("cannot connect to peer: {}; active {}, in queue {}",
@@ -216,7 +216,7 @@ namespace libp2p::protocol::kademlia {
     });
 
     // Check if gotten some message
-    if (not msg_res) {
+    if (!msg_res) {
       log_.warn("Result from {} is failed: {}; active {}, in queue {}",
                 session->stream()->remotePeerId().value().toBase58(),
                 msg_res.error(),
@@ -227,7 +227,7 @@ namespace libp2p::protocol::kademlia {
     auto &msg = msg_res.value();
 
     // Skip inappropriate messages
-    if (not match(msg)) {
+    if (!match(msg)) {
       BOOST_UNREACHABLE_RETURN();
     }
 
@@ -259,7 +259,7 @@ namespace libp2p::protocol::kademlia {
                 std::span(peer.info.addresses.data(),
                           peer.info.addresses.size()),
                 peer::ttl::kDay);
-        if (not add_addr_res) {
+        if (!add_addr_res) {
           continue;
         }
 

--- a/src/protocol/kademlia/impl/find_peer_executor.cpp
+++ b/src/protocol/kademlia/impl/find_peer_executor.cpp
@@ -109,7 +109,7 @@ namespace libp2p::protocol::kademlia {
 
     auto self_peer_id = host_->getId();
 
-    while (started_ and not done_ and not queue_.empty()
+    while (started_ and !done_ and !queue_.empty()
            and requests_in_progress_ < config_.requestConcurency) {
       auto peer_id = *queue_.top();
       queue_.pop();

--- a/src/protocol/kademlia/impl/find_providers_executor.cpp
+++ b/src/protocol/kademlia/impl/find_providers_executor.cpp
@@ -123,7 +123,7 @@ namespace libp2p::protocol::kademlia {
 
     auto self_peer_id = host_->getId();
 
-    while (started_ and not done_ and not queue_.empty()
+    while (started_ and !done_ and !queue_.empty()
            and requests_in_progress_ < config_.requestConcurency) {
       auto peer_id = *queue_.top();
       queue_.pop();

--- a/src/protocol/kademlia/impl/find_providers_executor.cpp
+++ b/src/protocol/kademlia/impl/find_providers_executor.cpp
@@ -71,7 +71,7 @@ namespace libp2p::protocol::kademlia {
     serialized_request_ = std::make_shared<std::vector<uint8_t>>();
 
     boost::optional<peer::PeerInfo> self_announce;
-    if (not config_.passiveMode) {
+    if (!config_.passiveMode) {
       self_announce = host_->getPeerInfo();
     }
 
@@ -99,7 +99,7 @@ namespace libp2p::protocol::kademlia {
 
   void FindProvidersExecutor::done() {
     bool x = false;
-    if (not done_.compare_exchange_strong(x, true)) {
+    if (!done_.compare_exchange_strong(x, true)) {
       return;
     }
 
@@ -183,7 +183,7 @@ namespace libp2p::protocol::kademlia {
   }
 
   void FindProvidersExecutor::onConnected(StreamAndProtocolOrError stream_res) {
-    if (not stream_res) {
+    if (!stream_res) {
       --requests_in_progress_;
 
       log_.debug("cannot connect to peer: {}; active {}, in queue {}",
@@ -232,7 +232,7 @@ namespace libp2p::protocol::kademlia {
     });
 
     // Check if gotten some message
-    if (not msg_res) {
+    if (!msg_res) {
       log_.warn("Result from {} is failed: {}; active {}, in queue {}",
                 session->stream()->remotePeerId().value().toBase58(),
                 msg_res.error(),
@@ -243,7 +243,7 @@ namespace libp2p::protocol::kademlia {
     auto &msg = msg_res.value();
 
     // Skip inappropriate messages
-    if (not match(msg)) {
+    if (!match(msg)) {
       BOOST_UNREACHABLE_RETURN();
     }
 
@@ -273,7 +273,7 @@ namespace libp2p::protocol::kademlia {
                 std::span(peer.info.addresses.data(),
                           peer.info.addresses.size()),
                 peer::ttl::kDay);
-        if (not add_addr_res) {
+        if (!add_addr_res) {
           continue;
         }
 
@@ -302,7 +302,7 @@ namespace libp2p::protocol::kademlia {
                 std::span(peer.info.addresses.data(),
                           peer.info.addresses.size()),
                 peer::ttl::kDay);
-        if (not add_addr_res) {
+        if (!add_addr_res) {
           continue;
         }
 

--- a/src/protocol/kademlia/impl/get_value_executor.cpp
+++ b/src/protocol/kademlia/impl/get_value_executor.cpp
@@ -83,7 +83,7 @@ namespace libp2p::protocol::kademlia {
     serialized_request_ = std::make_shared<std::vector<uint8_t>>();
 
     boost::optional<peer::PeerInfo> self_announce;
-    if (not config_.passiveMode) {
+    if (!config_.passiveMode) {
       self_announce = host_->getPeerInfo();
     }
 
@@ -177,7 +177,7 @@ namespace libp2p::protocol::kademlia {
   }
 
   void GetValueExecutor::onConnected(StreamAndProtocolOrError stream_res) {
-    if (not stream_res) {
+    if (!stream_res) {
       --requests_in_progress_;
 
       log_.debug("cannot connect to peer: {}; active {}, in queue {}",
@@ -227,7 +227,7 @@ namespace libp2p::protocol::kademlia {
     });
 
     // Check if gotten some message
-    if (not msg_res) {
+    if (!msg_res) {
       log_.warn("Result from {} failed: {}; active {}, in queue {}",
                 session->stream()->remotePeerId().value().toBase58(),
                 msg_res.error(),
@@ -238,7 +238,7 @@ namespace libp2p::protocol::kademlia {
     auto &msg = msg_res.value();
 
     // Skip inappropriate messages
-    if (not match(msg)) {
+    if (!match(msg)) {
       BOOST_UNREACHABLE_RETURN();
     }
 
@@ -268,7 +268,7 @@ namespace libp2p::protocol::kademlia {
                 std::span(peer.info.addresses.data(),
                           peer.info.addresses.size()),
                 peer::ttl::kDay);
-        if (not add_addr_res) {
+        if (!add_addr_res) {
           continue;
         }
 
@@ -293,7 +293,7 @@ namespace libp2p::protocol::kademlia {
       auto &value = msg.record.value().value;
 
       auto validation_res = validator_->validate(key_, value);
-      if (not validation_res.has_value()) {
+      if (!validation_res.has_value()) {
         log_.debug("Result from {} is invalid", remote_peer_id.toBase58());
         return;
       }
@@ -314,7 +314,7 @@ namespace libp2p::protocol::kademlia {
                    [](auto &record) { return record.value; });
 
     auto index_res = validator_->select(key_, values);
-    if (not index_res.has_value()) {
+    if (!index_res.has_value()) {
       log_.debug("Can't select best value of {} provided", values.size());
       return;
     }
@@ -336,7 +336,7 @@ namespace libp2p::protocol::kademlia {
       }
     }
 
-    if (not addressees.empty()) {
+    if (!addressees.empty()) {
       auto put_value_executor = executor_factory_->createPutValueExecutor(
           key_, best, std::move(addressees));
       [[maybe_unused]] auto res = put_value_executor->start();

--- a/src/protocol/kademlia/impl/get_value_executor.cpp
+++ b/src/protocol/kademlia/impl/get_value_executor.cpp
@@ -106,7 +106,7 @@ namespace libp2p::protocol::kademlia {
 
     auto self_peer_id = host_->getId();
 
-    while (started_ and not done_ and not queue_.empty()
+    while (started_ and !done_ and !queue_.empty()
            and requests_in_progress_ < config_.requestConcurency) {
       auto peer_id = *queue_.top();
       queue_.pop();

--- a/src/protocol/kademlia/impl/kademlia_impl.cpp
+++ b/src/protocol/kademlia/impl/kademlia_impl.cpp
@@ -58,7 +58,7 @@ namespace libp2p::protocol::kademlia {
   }
 
   void KademliaImpl::start() {
-    BOOST_ASSERT(not started_);
+    BOOST_ASSERT(!started_);
     if (started_) {
       return;
     }
@@ -364,7 +364,7 @@ namespace libp2p::protocol::kademlia {
     log_.debug("MSG: GetValue ({})", multi::detail::encodeBase58(msg.key));
 
     if (auto providers = content_routing_table_->getProvidersFor(msg.key);
-        not providers.empty()) {
+        !providers.empty()) {
       std::vector<Message::Peer> peers;
       peers.reserve(config_.closerPeerCount);
 

--- a/src/protocol/kademlia/impl/kademlia_impl.cpp
+++ b/src/protocol/kademlia/impl/kademlia_impl.cpp
@@ -698,7 +698,7 @@ namespace libp2p::protocol::kademlia {
     log_.debug("Performing periodic replication");
 
     auto records = storage_->getAllRecords();
-    for (const auto& [key, value]: records) {
+    for (const auto &[key, value] : records) {
       replicateRecord(key, value, false);  // false = don't extend expiration
     }
   }
@@ -707,43 +707,49 @@ namespace libp2p::protocol::kademlia {
     log_.debug("Performing periodic republishing");
 
     auto records = storage_->getAllRecords();
-    for (const auto& [key, value] : records) {
+    for (const auto &[key, value] : records) {
       replicateRecord(key, value, true);  // true = extend expiration
     }
   }
 
-  std::vector<PeerId> KademliaImpl::getClosestPeers(const Key& key, size_t count) {
+  std::vector<PeerId> KademliaImpl::getClosestPeers(const Key &key,
+                                                    size_t count) {
     std::vector<PeerId> closest_peers;
-    
+
     // Get peers from peer routing table
     HashedKey hashed_key(key);
     auto peers = peer_routing_table_->getNearestPeers(hashed_key.hash, count);
-    
-    for (const auto& peer : peers) {
-      if (peer != self_id_) { // Don't include self
+
+    for (const auto &peer : peers) {
+      if (peer != self_id_) {  // Don't include self
         closest_peers.push_back(peer);
       }
     }
-    
+
     return closest_peers;
   }
 
-  void KademliaImpl::replicateRecord(const Key& key, const Value& value, bool extend_expiration) {
-    // If republishing, extend local expiration by putting the value back to storage
+  void KademliaImpl::replicateRecord(const Key &key,
+                                     const Value &value,
+                                     bool extend_expiration) {
+    // If republishing, extend local expiration by putting the value back to
+    // storage
     if (extend_expiration) {
       auto put_res = storage_->putValue(key, value);
       if (!put_res) {
         log_.warn("Republish: failed to extend expiration for key: {}: {}",
-                  multi::detail::encodeBase58(key), put_res.error());
+                  multi::detail::encodeBase58(key),
+                  put_res.error());
       }
     }
 
-    auto closest_peers = getClosestPeers(key, 
-        extend_expiration ? config_.periodicRepublishing.peers_per_cycle 
+    auto closest_peers = getClosestPeers(
+        key,
+        extend_expiration ? config_.periodicRepublishing.peers_per_cycle
                           : config_.periodicReplication.peers_per_cycle);
-    
+
     if (closest_peers.empty()) {
-      log_.debug("No peers available for replication/republishing of key: {}", 
+      log_.debug("No peers available for replication/republishing of key: {}",
                  multi::detail::encodeBase58(key));
       return;
     }
@@ -752,9 +758,9 @@ namespace libp2p::protocol::kademlia {
     auto executor = createPutValueExecutor(key, value, closest_peers);
     if (executor) {
       std::ignore = executor->start();
-      log_.debug("Started {} for key: {} to {} peers", 
+      log_.debug("Started {} for key: {} to {} peers",
                  extend_expiration ? "republishing" : "replication",
-                 multi::detail::encodeBase58(key), 
+                 multi::detail::encodeBase58(key),
                  closest_peers.size());
     }
   }

--- a/src/protocol/kademlia/impl/kademlia_impl.cpp
+++ b/src/protocol/kademlia/impl/kademlia_impl.cpp
@@ -109,7 +109,7 @@ namespace libp2p::protocol::kademlia {
             .getChannel<event::network::OnPeerDisconnectedChannel>()
             .subscribe([weak_self{weak_from_this()}](const PeerId &peer) {
               auto self = weak_self.lock();
-              if (not self) {
+              if (!self) {
                 return;
               }
               std::ignore =
@@ -142,7 +142,7 @@ namespace libp2p::protocol::kademlia {
                    const outcome::result<PeerInfo> &,
                    std::vector<PeerId> succeeded_peers) {
                  auto self = weak_self.lock();
-                 if (not self) {
+                 if (!self) {
                    return;
                  }
                  std::ignore = self->createPutValueExecutor(
@@ -181,7 +181,7 @@ namespace libp2p::protocol::kademlia {
 
     content_routing_table_->addProvider(key, self_id_);
 
-    if (not need_notify) {
+    if (!need_notify) {
       return outcome::success();
     }
 
@@ -196,7 +196,7 @@ namespace libp2p::protocol::kademlia {
 
     // Try to find locally
     auto providers = content_routing_table_->getProvidersFor(key, limit);
-    if (not providers.empty()) {
+    if (!providers.empty()) {
       if (limit > 0 && providers.size() > limit) {
         std::vector<PeerInfo> result;
         result.reserve(limit);
@@ -254,7 +254,7 @@ namespace libp2p::protocol::kademlia {
             peer_info.id,
             std::span(peer_info.addresses.data(), peer_info.addresses.size()),
             permanent ? peer::ttl::kPermanent : peer::ttl::kDay);
-    if (not upsert_res) {
+    if (!upsert_res) {
       log_.debug("{} was skipped at addind to peer routing table: {}",
                  peer_info.id.toBase58(),
                  upsert_res.error());
@@ -263,7 +263,7 @@ namespace libp2p::protocol::kademlia {
 
     auto update_res =
         peer_routing_table_->update(peer_info.id, permanent, is_connected);
-    if (not update_res) {
+    if (!update_res) {
       log_.debug("{} was not added to peer routing table: {}",
                  peer_info.id.toBase58(),
                  update_res.error());
@@ -286,7 +286,7 @@ namespace libp2p::protocol::kademlia {
 
     // Try to find locally
     auto peer_info = host_->getPeerRepository().getPeerInfo(peer_id);
-    if (not peer_info.addresses.empty()) {
+    if (!peer_info.addresses.empty()) {
       scheduler_->schedule(
           [handler = std::move(handler), peer_info = std::move(peer_info)] {
             handler(peer_info, {});
@@ -330,7 +330,7 @@ namespace libp2p::protocol::kademlia {
 
   void KademliaImpl::onPutValue(const std::shared_ptr<Session> &session,
                                 Message &&msg) {
-    if (not msg.record) {
+    if (!msg.record) {
       log_.warn("incoming PutValue failed: no record in message");
       return;
     }
@@ -339,7 +339,7 @@ namespace libp2p::protocol::kademlia {
     log_.debug("MSG: PutValue ({})", multi::detail::encodeBase58(key));
 
     auto validation_res = validator_->validate(key, value);
-    if (not validation_res) {
+    if (!validation_res) {
       log_.warn("incoming PutValue failed: {}", validation_res.error());
       return;
     }
@@ -395,7 +395,7 @@ namespace libp2p::protocol::kademlia {
 
   void KademliaImpl::onAddProvider(const std::shared_ptr<Session> &session,
                                    Message &&msg) {
-    if (not msg.provider_peers) {
+    if (!msg.provider_peers) {
       log_.warn("AddProvider failed: no provider_peers im message");
       return;
     }
@@ -426,7 +426,7 @@ namespace libp2p::protocol::kademlia {
     auto peer_ids = content_routing_table_->getProvidersFor(
         msg.key, config_.closerPeerCount * 2);
 
-    if (not peer_ids.empty()) {
+    if (!peer_ids.empty()) {
       std::vector<Message::Peer> peers;
       peers.reserve(config_.closerPeerCount);
 
@@ -442,7 +442,7 @@ namespace libp2p::protocol::kademlia {
         }
       }
 
-      if (not peers.empty()) {
+      if (!peers.empty()) {
         msg.provider_peers = std::move(peers);
       }
     }
@@ -450,7 +450,7 @@ namespace libp2p::protocol::kademlia {
     peer_ids = peer_routing_table_->getNearestPeers(
         NodeId::hash(msg.key), config_.closerPeerCount * 2);
 
-    if (not peer_ids.empty()) {
+    if (!peer_ids.empty()) {
       std::vector<Message::Peer> peers;
       peers.reserve(config_.closerPeerCount);
 
@@ -466,7 +466,7 @@ namespace libp2p::protocol::kademlia {
         }
       }
 
-      if (not peers.empty()) {
+      if (!peers.empty()) {
         msg.closer_peers = std::move(peers);
       }
     }
@@ -516,7 +516,7 @@ namespace libp2p::protocol::kademlia {
       }
     }
 
-    if (not peers.empty()) {
+    if (!peers.empty()) {
       msg.closer_peers = std::move(peers);
     }
 
@@ -655,13 +655,13 @@ namespace libp2p::protocol::kademlia {
   // Periodic behavior is driven by configuration only; no runtime setters
 
   void KademliaImpl::setReplicationTimer() {
-    if (not config_.periodicReplication.enabled) {
+    if (!config_.periodicReplication.enabled) {
       return;
     }
     replication_timer_ = scheduler_->scheduleWithHandle(
         [weak_self{weak_from_this()}] {
           auto self = weak_self.lock();
-          if (not self) {
+          if (!self) {
             return;
           }
           self->setReplicationTimer();
@@ -671,13 +671,13 @@ namespace libp2p::protocol::kademlia {
   }
 
   void KademliaImpl::setRepublishingTimer() {
-    if (not config_.periodicRepublishing.enabled) {
+    if (!config_.periodicRepublishing.enabled) {
       return;
     }
     republishing_timer_ = scheduler_->scheduleWithHandle(
         [weak_self{weak_from_this()}] {
           auto self = weak_self.lock();
-          if (not self) {
+          if (!self) {
             return;
           }
           self->setRepublishingTimer();

--- a/src/protocol/kademlia/impl/peer_routing_table_impl.cpp
+++ b/src/protocol/kademlia/impl/peer_routing_table_impl.cpp
@@ -74,7 +74,7 @@ namespace libp2p::protocol::kademlia {
 
     for (auto it = peers_.rbegin(); it != peers_.rend(); ++it) {
       // https://github.com/libp2p/rust-libp2p/blob/3837e33cd4c40ae703138e6aed6f6c9d52928a80/protocols/kad/src/kbucket/bucket.rs#L310-L366
-      if (it->is_replaceable and not it->is_connected) {
+      if (it->is_replaceable and !it->is_connected) {
         result = std::move(it->peer_id);
         peers_.erase((++it).base());
         break;
@@ -161,7 +161,7 @@ namespace libp2p::protocol::kademlia {
     if (bucket_index) {
       if (auto i = *bucket_index) {
         append(i);
-        for (--i; i != 0 and not done(); --i) {
+        for (--i; i != 0 and !done(); --i) {
           if (bit(i)) {
             append(i);
           }
@@ -171,7 +171,7 @@ namespace libp2p::protocol::kademlia {
     if (!done()) {
       append(0);
     }
-    for (size_t i = 1; i < 256 and not done(); ++i) {
+    for (size_t i = 1; i < 256 and !done(); ++i) {
       if (!bit(i)) {
         append(i);
       }
@@ -219,13 +219,13 @@ namespace libp2p::protocol::kademlia {
     }
 
     if (bucket.size() < config_.maxBucketSize) {
-      bucket.emplaceToFront(pid, not is_permanent, is_connected);
+      bucket.emplaceToFront(pid, !is_permanent, is_connected);
       bus_->getChannel<event::protocol::kademlia::PeerAddedChannel>().publish(
           pid);
       return true;
     }
 
-    return replacePeer(bucket, pid, not is_permanent, is_connected, *bus_);
+    return replacePeer(bucket, pid, !is_permanent, is_connected, *bus_);
   }
 
   size_t PeerRoutingTableImpl::size() const {

--- a/src/protocol/kademlia/impl/peer_routing_table_impl.cpp
+++ b/src/protocol/kademlia/impl/peer_routing_table_impl.cpp
@@ -135,7 +135,7 @@ namespace libp2p::protocol::kademlia {
 
   void PeerRoutingTableImpl::remove(const peer::PeerId &peer_id) {
     auto bucket_index = getBucketIndex(NodeId{peer_id});
-    if (not bucket_index) {
+    if (!bucket_index) {
       return;
     }
     auto &bucket = buckets_.at(*bucket_index);
@@ -168,11 +168,11 @@ namespace libp2p::protocol::kademlia {
         }
       }
     }
-    if (not done()) {
+    if (!done()) {
       append(0);
     }
     for (size_t i = 1; i < 256 and not done(); ++i) {
-      if (not bit(i)) {
+      if (!bit(i)) {
         append(i);
       }
     }
@@ -204,7 +204,7 @@ namespace libp2p::protocol::kademlia {
                                                      bool is_permanent,
                                                      bool is_connected) {
     auto bucket_index = getBucketIndex(NodeId{pid});
-    if (not bucket_index) {
+    if (!bucket_index) {
       return true;
     }
     auto &bucket = buckets_.at(*bucket_index);

--- a/src/protocol/kademlia/impl/put_value_executor.cpp
+++ b/src/protocol/kademlia/impl/put_value_executor.cpp
@@ -63,7 +63,7 @@ namespace libp2p::protocol::kademlia {
   };
 
   void PutValueExecutor::spawn() {
-    while (started_ and not done_ and addressees_idx_ < addressees_.size()
+    while (started_ and !done_ and addressees_idx_ < addressees_.size()
            and requests_in_progress_ < config_.requestConcurency) {
       auto &peer_id = addressees_[addressees_idx_++];
       auto peer_info = host_->getPeerRepository().getPeerInfo(peer_id);

--- a/src/protocol/kademlia/impl/put_value_executor.cpp
+++ b/src/protocol/kademlia/impl/put_value_executor.cpp
@@ -111,7 +111,7 @@ namespace libp2p::protocol::kademlia {
   }
 
   void PutValueExecutor::onConnected(StreamAndProtocolOrError stream_res) {
-    if (not stream_res) {
+    if (!stream_res) {
       --requests_in_progress_;
 
       log_.debug("cannot connect to peer: {}; active {}, in queue {}",

--- a/src/protocol/kademlia/impl/session.cpp
+++ b/src/protocol/kademlia/impl/session.cpp
@@ -80,7 +80,7 @@ namespace libp2p::protocol::kademlia {
   void Session::read(std::shared_ptr<ResponseHandler> response_handler) {
     read([self{shared_from_this()},
           response_handler](outcome::result<Message> r) {
-      if (r and not response_handler->match(r.value())) {
+      if (r and !response_handler->match(r.value())) {
         r = Error::UNEXPECTED_MESSAGE_TYPE;
       }
       response_handler->onResult(self, std::move(r));

--- a/src/protocol/kademlia/impl/session.cpp
+++ b/src/protocol/kademlia/impl/session.cpp
@@ -32,12 +32,12 @@ namespace libp2p::protocol::kademlia {
     framing_->read([self{shared_from_this()}, on_read{std::move(on_read)}](
                        basic::MessageReadWriter::ReadCallback r) {
       self->timer_.reset();
-      if (not r) {
+      if (!r) {
         on_read(r.error());
         return;
       }
       Message msg;
-      if (not msg.deserialize(*r.value())) {
+      if (!msg.deserialize(*r.value())) {
         on_read(Error::MESSAGE_DESERIALIZE_ERROR);
         return;
       }
@@ -54,7 +54,7 @@ namespace libp2p::protocol::kademlia {
                    on_write{std::move(on_write)},
                    buf](outcome::result<void> r) {
                     self->timer_.reset();
-                    if (not r) {
+                    if (!r) {
                       on_write(r.error());
                       return;
                     }
@@ -67,10 +67,10 @@ namespace libp2p::protocol::kademlia {
           weak_session_host{std::move(weak_session_host)}](
              outcome::result<Message> r) {
       auto session_host = weak_session_host.lock();
-      if (not session_host) {
+      if (!session_host) {
         return;
       }
-      if (not r) {
+      if (!r) {
         return;
       }
       session_host->onMessage(self, std::move(r.value()));
@@ -90,14 +90,14 @@ namespace libp2p::protocol::kademlia {
   void Session::write(const Message &msg,
                       std::weak_ptr<SessionHost> weak_session_host) {
     Bytes pb;
-    if (not msg.serialize(pb)) {
+    if (!msg.serialize(pb)) {
       return;
     }
     write(pb,
           [self{shared_from_this()},
            weak_session_host{std::move(weak_session_host)}](
               outcome::result<void> r) {
-            if (not r) {
+            if (!r) {
               return;
             }
             self->read(weak_session_host);
@@ -109,7 +109,7 @@ namespace libp2p::protocol::kademlia {
     write(
         frame,
         [self{shared_from_this()}, response_handler](outcome::result<void> r) {
-          if (not r) {
+          if (!r) {
             response_handler->onResult(self, r.error());
             return;
           }
@@ -126,13 +126,13 @@ namespace libp2p::protocol::kademlia {
       return;
     }
     auto scheduler = scheduler_.lock();
-    if (not scheduler) {
+    if (!scheduler) {
       return;
     }
     timer_ = scheduler->scheduleWithHandle(
         [weak_self = weak_from_this()] {
           auto self = weak_self.lock();
-          if (not self) {
+          if (!self) {
             return;
           }
           self->stream_->reset();

--- a/src/protocol/kademlia/impl/storage_impl.cpp
+++ b/src/protocol/kademlia/impl/storage_impl.cpp
@@ -110,7 +110,7 @@ namespace libp2p::protocol::kademlia {
     refresh_timer_ = scheduler_->scheduleWithHandle(
         [weak_self{weak_from_this()}] {
           auto self = weak_self.lock();
-          if (not self) {
+          if (!self) {
             return;
           }
           self->onRefreshTimer();

--- a/src/protocol/kademlia/impl/storage_impl.cpp
+++ b/src/protocol/kademlia/impl/storage_impl.cpp
@@ -121,9 +121,9 @@ namespace libp2p::protocol::kademlia {
   std::vector<std::pair<Key, Value>> StorageImpl::getAllRecords() const {
     std::vector<std::pair<Key, Value>> records;
     auto now = scheduler_->now();
-    
+
     // Iterate through all records and get their values from backend
-    for (const auto& record : *table_) {
+    for (const auto &record : *table_) {
       // Only include non-expired records
       if (record.expire_time > now) {
         auto value_result = backend_->getValue(record.key);
@@ -132,7 +132,7 @@ namespace libp2p::protocol::kademlia {
         }
       }
     }
-    
+
     return records;
   }
 }  // namespace libp2p::protocol::kademlia

--- a/src/protocol/kademlia/message.cpp
+++ b/src/protocol/kademlia/message.cpp
@@ -123,12 +123,12 @@ namespace libp2p::protocol::kademlia {
       assign_record(record.value(), pb_msg.record());
     }
     auto closer_res = assign_peers(closer_peers, pb_msg.closerpeers());
-    if (not closer_res) {
+    if (!closer_res) {
       error_message_ = fmt::format("Bad closer peers: {}", closer_res.error());
       return false;
     }
     auto provider_res = assign_peers(provider_peers, pb_msg.providerpeers());
-    if (not provider_res) {
+    if (!provider_res) {
       error_message_ =
           fmt::format("Bad provider peers: {}", provider_res.error());
       return false;

--- a/src/protocol/ping/ping_client_session.cpp
+++ b/src/protocol/ping/ping_client_session.cpp
@@ -42,7 +42,7 @@ namespace libp2p::protocol {
   }
 
   void PingClientSession::write() {
-    if (not is_started_ or closed_ or stream_->isClosedForWrite()) {
+    if (!is_started_ or closed_ or stream_->isClosedForWrite()) {
       return;
     }
 
@@ -73,7 +73,7 @@ namespace libp2p::protocol {
   }
 
   void PingClientSession::read() {
-    if (not is_started_ or closed_ or stream_->isClosedForRead()) {
+    if (!is_started_ or closed_ or stream_->isClosedForRead()) {
       return;
     }
 

--- a/src/security/noise/crypto/state.cpp
+++ b/src/security/noise/crypto/state.cpp
@@ -154,7 +154,7 @@ namespace libp2p::security::noise {
 
   outcome::result<Bytes> SymmetricState::encryptAndHash(BytesIn precompiled_out,
                                                         BytesIn plaintext) {
-    if (not has_key_) {
+    if (!has_key_) {
       Bytes result(precompiled_out.size() + plaintext.size());
       OUTCOME_TRY(mixHash(plaintext));
       std::copy_n(
@@ -180,7 +180,7 @@ namespace libp2p::security::noise {
 
   outcome::result<Bytes> SymmetricState::decryptAndHash(BytesIn precompiled_out,
                                                         BytesIn ciphertext) {
-    if (not has_key_) {
+    if (!has_key_) {
       Bytes result(precompiled_out.size() + ciphertext.size());
       OUTCOME_TRY(mixHash(ciphertext));
       std::copy_n(
@@ -298,7 +298,7 @@ namespace libp2p::security::noise {
       preshared_key_placement = config.preshared_key_placement_.value();
     }
     std::string psk_modifier;
-    if (not preshared_key_.empty()) {
+    if (!preshared_key_.empty()) {
       if (32 != preshared_key_.size()) {
         return Error::WRONG_PRESHARED_KEY_SIZE;
       }
@@ -328,16 +328,16 @@ namespace libp2p::security::noise {
         OUTCOME_TRY(symmetric_state_->mixHash(local_static_kp_.pub));
       } else if (is_initiator_ and MessagePattern::E == m) {
         OUTCOME_TRY(symmetric_state_->mixHash(local_ephemeral_kp_.pub));
-      } else if (not is_initiator_ and MessagePattern::S == m) {
+      } else if (!is_initiator_ and MessagePattern::S == m) {
         OUTCOME_TRY(symmetric_state_->mixHash(remote_static_pubkey_));
-      } else if (not is_initiator_ and MessagePattern::E == m) {
+      } else if (!is_initiator_ and MessagePattern::E == m) {
         OUTCOME_TRY(symmetric_state_->mixHash(remote_ephemeral_pubkey_));
       }
     }
     for (const auto &m : config.pattern_.responderPreMessages) {
-      if (not is_initiator_ and MessagePattern::S == m) {
+      if (!is_initiator_ and MessagePattern::S == m) {
         OUTCOME_TRY(symmetric_state_->mixHash(local_static_kp_.pub));
-      } else if (not is_initiator_ and MessagePattern::E == m) {
+      } else if (!is_initiator_ and MessagePattern::E == m) {
         OUTCOME_TRY(symmetric_state_->mixHash(local_ephemeral_kp_.pub));
       } else if (is_initiator_ and MessagePattern::S == m) {
         OUTCOME_TRY(symmetric_state_->mixHash(remote_static_pubkey_));
@@ -352,7 +352,7 @@ namespace libp2p::security::noise {
   outcome::result<HandshakeState::MessagingResult> HandshakeState::writeMessage(
       BytesIn precompiled_out, BytesIn payload) {
     OUTCOME_TRY(isInitialized());
-    if (not should_write_) {
+    if (!should_write_) {
       return Error::UNEXPECTED_WRITE_CALL;
     }
     if (message_idx_ > static_cast<int64_t>(message_patterns_.size()) - 1) {
@@ -409,7 +409,7 @@ namespace libp2p::security::noise {
                local_ephemeral_kp_.pub.begin(),
                local_ephemeral_kp_.pub.end());
     OUTCOME_TRY(symmetric_state_->mixHash(local_ephemeral_kp_.pub));
-    if (not preshared_key_.empty()) {
+    if (!preshared_key_.empty()) {
       OUTCOME_TRY(symmetric_state_->mixKey(local_ephemeral_kp_.pub));
     }
     return outcome::success();
@@ -538,7 +538,7 @@ namespace libp2p::security::noise {
     remote_ephemeral_pubkey_ =
         Bytes{message.begin(), message.begin() + expected};
     OUTCOME_TRY(symmetric_state_->mixHash(remote_ephemeral_pubkey_));
-    if (not preshared_key_.empty()) {
+    if (!preshared_key_.empty()) {
       OUTCOME_TRY(symmetric_state_->mixKey(remote_ephemeral_pubkey_));
     }
     Bytes(message.begin() + expected, message.end()).swap(message);
@@ -553,7 +553,7 @@ namespace libp2p::security::noise {
     if (static_cast<int64_t>(message.size()) < expected) {
       return Error::MESSAGE_TOO_SHORT;
     }
-    if (not remote_static_pubkey_.empty()) {
+    if (!remote_static_pubkey_.empty()) {
       return Error::REMOTE_KEY_ALREADY_SET;
     }
     auto decrypted = symmetric_state_->decryptAndHash(

--- a/src/security/noise/handshake.cpp
+++ b/src/security/noise/handshake.cpp
@@ -171,7 +171,7 @@ namespace libp2p::security::noise {
         signature_correct,
         crypto_provider_->verify(
             to_verify, handy_payload.identity_sig, handy_payload.identity_key));
-    if (not signature_correct) {
+    if (!signature_correct) {
       SL_TRACE(log_, "Remote peer's payload signature verification failed");
       return std::errc::owner_dead;
     }
@@ -272,11 +272,11 @@ namespace libp2p::security::noise {
       log_->error("handshake failed, {}", secured.error());
       return connection_cb_(secured.error());
     }
-    if (not secured.value()) {
+    if (!secured.value()) {
       log_->error("handshake failed for unknown reason");
       return connection_cb_(std::errc::io_error);
     }
-    if (not remote_peer_pubkey_) {
+    if (!remote_peer_pubkey_) {
       log_->error("Remote peer static pubkey remains unknown");
       return connection_cb_(std::errc::connection_aborted);
     }

--- a/src/security/noise/handshake_message_marshaller_impl.cpp
+++ b/src/security/noise/handshake_message_marshaller_impl.cpp
@@ -62,7 +62,7 @@ namespace libp2p::security::noise {
     OUTCOME_TRY(proto_msg, handyToProto(msg));
     Bytes out_msg(proto_msg.ByteSizeLong());
     if (!proto_msg.SerializeToArray(out_msg.data(),
-                                       static_cast<int>(out_msg.size()))) {
+                                    static_cast<int>(out_msg.size()))) {
       return Error::MESSAGE_SERIALIZING_ERROR;
     }
     return out_msg;
@@ -72,7 +72,7 @@ namespace libp2p::security::noise {
   HandshakeMessageMarshallerImpl::unmarshal(BytesIn msg_bytes) const {
     protobuf::NoiseHandshakePayload proto_msg;
     if (!proto_msg.ParseFromArray(msg_bytes.data(),
-                                     static_cast<int>(msg_bytes.size()))) {
+                                  static_cast<int>(msg_bytes.size()))) {
       return Error::MESSAGE_DESERIALIZING_ERROR;
     }
     return protoToHandy(proto_msg);

--- a/src/security/noise/handshake_message_marshaller_impl.cpp
+++ b/src/security/noise/handshake_message_marshaller_impl.cpp
@@ -61,7 +61,7 @@ namespace libp2p::security::noise {
       const HandshakeMessage &msg) const {
     OUTCOME_TRY(proto_msg, handyToProto(msg));
     Bytes out_msg(proto_msg.ByteSizeLong());
-    if (not proto_msg.SerializeToArray(out_msg.data(),
+    if (!proto_msg.SerializeToArray(out_msg.data(),
                                        static_cast<int>(out_msg.size()))) {
       return Error::MESSAGE_SERIALIZING_ERROR;
     }
@@ -71,7 +71,7 @@ namespace libp2p::security::noise {
   outcome::result<std::pair<HandshakeMessage, crypto::ProtobufKey>>
   HandshakeMessageMarshallerImpl::unmarshal(BytesIn msg_bytes) const {
     protobuf::NoiseHandshakePayload proto_msg;
-    if (not proto_msg.ParseFromArray(msg_bytes.data(),
+    if (!proto_msg.ParseFromArray(msg_bytes.data(),
                                      static_cast<int>(msg_bytes.size()))) {
       return Error::MESSAGE_DESERIALIZING_ERROR;
     }

--- a/src/security/noise/noise_connection.cpp
+++ b/src/security/noise/noise_connection.cpp
@@ -46,7 +46,7 @@ namespace libp2p::connection {
 
   void NoiseConnection::readSome(BytesOut out,
                                  libp2p::basic::Reader::ReadCallbackFunc cb) {
-    if (not frame_buffer_->empty()) {
+    if (!frame_buffer_->empty()) {
       auto n{std::min(out.size(), frame_buffer_->size())};
       auto begin{frame_buffer_->begin()};
       auto end{begin + static_cast<int64_t>(n)};

--- a/src/security/secio/secio_connection.cpp
+++ b/src/security/secio/secio_connection.cpp
@@ -191,7 +191,7 @@ namespace libp2p::connection {
       return;
     }
 
-    if (not user_data_buffer_.empty()) {
+    if (!user_data_buffer_.empty()) {
       size_t to_read{std::min(user_data_buffer_.size(), out.size())};
       popUserData(out, to_read);
       SL_TRACE(log_, "Successfully read {} bytes", to_read);

--- a/src/security/secio/secio_dialer.cpp
+++ b/src/security/secio/secio_dialer.cpp
@@ -158,7 +158,7 @@ namespace libp2p::security::secio {
 
   outcome::result<crypto::Buffer> Dialer::generateSharedSecret(
       crypto::Buffer remote_ephemeral_public_key) const {
-    if (not ekey_pair_) {
+    if (!ekey_pair_) {
       return Error::INTERNAL_FAILURE;
     }
     OUTCOME_TRY(shared_secret,

--- a/src/security/secio/secio_dialer.cpp
+++ b/src/security/secio/secio_dialer.cpp
@@ -85,8 +85,8 @@ namespace {
 namespace libp2p::security::secio {
   Dialer::Dialer(std::shared_ptr<connection::LayerConnection> connection)
       : rw{std::make_shared<libp2p::basic::ProtobufMessageReadWriter>(
-          std::make_shared<libp2p::basic::MessageReadWriterBigEndian>(
-              std::move(connection)))} {}
+            std::make_shared<libp2p::basic::MessageReadWriterBigEndian>(
+                std::move(connection)))} {}
 
   void Dialer::storeLocalPeerProposalBytes(
       const std::shared_ptr<std::vector<uint8_t>> &bytes) {

--- a/src/security/tls/tls_details.cpp
+++ b/src/security/tls/tls_details.cpp
@@ -58,7 +58,7 @@ namespace libp2p::security::tls_details {
     bool seen = false;
     for (int i = 0; i < X509_get_ext_count(cert); i++) {
       auto *ext = X509_get_ext(cert, i);
-      if (not X509_EXTENSION_get_critical(ext)) {
+      if (!X509_EXTENSION_get_critical(ext)) {
         continue;
       }
       if (X509_supported_extension(ext)) {

--- a/src/transport/quic/connection.cpp
+++ b/src/transport/quic/connection.cpp
@@ -51,7 +51,7 @@ namespace libp2p::transport {
   }
 
   bool QuicConnection::isClosed() const {
-    return not conn_ctx_;
+    return !conn_ctx_;
   }
 
   outcome::result<void> QuicConnection::close() {

--- a/src/transport/quic/connection.cpp
+++ b/src/transport/quic/connection.cpp
@@ -95,7 +95,7 @@ namespace libp2p::transport {
 
   outcome::result<std::shared_ptr<libp2p::connection::Stream>>
   QuicConnection::newStream() {
-    if (not conn_ctx_) {
+    if (!conn_ctx_) {
       return QuicError::CONN_CLOSED;
     }
     OUTCOME_TRY(stream, conn_ctx_->engine->newStream(conn_ctx_));

--- a/src/transport/quic/engine.cpp
+++ b/src/transport/quic/engine.cpp
@@ -39,7 +39,7 @@ namespace libp2p::transport::lsquic {
     lsquicInit();
 
     auto flags = 0;
-    if (not client) {
+    if (!client) {
       flags |= LSENG_SERVER;
     }
 
@@ -66,7 +66,7 @@ namespace libp2p::transport::lsquic {
       // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
       auto _conn_ctx = reinterpret_cast<lsquic_conn_ctx_t *>(conn_ctx);
       lsquic_conn_set_ctx(conn, _conn_ctx);
-      if (not op) {
+      if (!op) {
         stream_if.on_hsk_done(conn, LSQ_HSK_OK);
       }
       return _conn_ctx;
@@ -91,7 +91,7 @@ namespace libp2p::transport::lsquic {
       auto ok = status == LSQ_HSK_OK or status == LSQ_HSK_RESUMED_OK;
       auto op = qtils::optionTake(conn_ctx->connecting);
       auto res = [&]() -> outcome::result<std::shared_ptr<QuicConnection>> {
-        if (not ok) {
+        if (!ok) {
           return QuicError::HANDSHAKE_FAILED;
         }
         auto cert = SSL_get_peer_certificate(lsquic_conn_ssl(conn));
@@ -113,7 +113,7 @@ namespace libp2p::transport::lsquic {
         conn_ctx->conn = conn;
         return conn;
       }();
-      if (not res) {
+      if (!res) {
         lsquic_conn_close(conn);
       }
       if (op) {
@@ -205,7 +205,7 @@ namespace libp2p::transport::lsquic {
             auto cb = [weak_self{self->weak_from_this()}](
                           boost::system::error_code ec) {
               auto self = weak_self.lock();
-              if (not self) {
+              if (!self) {
                 return;
               }
               if (ec) {
@@ -229,7 +229,7 @@ namespace libp2p::transport::lsquic {
     };
 
     engine_ = lsquic_engine_new(flags, &api);
-    if (not engine_) {
+    if (!engine_) {
       throw std::logic_error{"lsquic_engine_new"};
     }
   }
@@ -283,7 +283,7 @@ namespace libp2p::transport::lsquic {
     conn_ctx->new_stream.emplace();
     lsquic_conn_make_stream(conn_ctx->ls_conn);
     auto stream = qtils::optionTake(conn_ctx->new_stream).value();
-    if (not stream) {
+    if (!stream) {
       return QuicError::CANT_OPEN_STREAM;
     }
     return stream;
@@ -318,7 +318,7 @@ namespace libp2p::transport::lsquic {
     auto want_flush = std::exchange(want_flush_, {});
     for (auto &weak_stream : want_flush) {
       auto stream = weak_stream.lock();
-      if (not stream) {
+      if (!stream) {
         continue;
       }
       if (stream->stream_ctx_ == nullptr) {
@@ -332,13 +332,13 @@ namespace libp2p::transport::lsquic {
     }
     lsquic_engine_process_conns(engine_);
     int us = 0;
-    if (not lsquic_engine_earliest_adv_tick(engine_, &us)) {
+    if (!lsquic_engine_earliest_adv_tick(engine_, &us)) {
       return;
     }
     timer_.expires_after(std::chrono::microseconds{us});
     auto cb = [weak_self{weak_from_this()}](boost::system::error_code ec) {
       auto self = weak_self.lock();
-      if (not self) {
+      if (!self) {
         return;
       }
       if (ec) {
@@ -364,7 +364,7 @@ namespace libp2p::transport::lsquic {
           auto cb =
               [weak_self{weak_from_this()}](boost::system::error_code ec) {
                 auto self = weak_self.lock();
-                if (not self) {
+                if (!self) {
                   return;
                 }
                 if (ec) {

--- a/src/transport/quic/listener.cpp
+++ b/src/transport/quic/listener.cpp
@@ -53,7 +53,7 @@ namespace libp2p::transport {
   }
 
   outcome::result<Multiaddress> QuicListener::getListenMultiaddr() const {
-    if (not server_) {
+    if (!server_) {
       return std::errc::not_connected;
     }
     return server_->local();

--- a/src/transport/quic/listener.cpp
+++ b/src/transport/quic/listener.cpp
@@ -60,7 +60,7 @@ namespace libp2p::transport {
   }
 
   bool QuicListener::isClosed() const {
-    return not server_;
+    return !server_;
   }
 
   outcome::result<void> QuicListener::close() {

--- a/src/transport/quic/stream.cpp
+++ b/src/transport/quic/stream.cpp
@@ -26,7 +26,7 @@ namespace libp2p::connection {
 
   void QuicStream::readSome(BytesOut out, basic::Reader::ReadCallbackFunc cb) {
     outcome::result<size_t> r = QuicError::STREAM_CLOSED;
-    if (not stream_ctx_) {
+    if (!stream_ctx_) {
       return cb(r);
     }
     if (stream_ctx_->reading) {
@@ -37,7 +37,7 @@ namespace libp2p::connection {
       stream_ctx_->reading.emplace(
           [weak_self{weak_from_this()}, out, cb{std::move(cb)}]() mutable {
             auto self = weak_self.lock();
-            if (not self) {
+            if (!self) {
               cb(QuicError::STREAM_CLOSED);
               return;
             }
@@ -59,7 +59,7 @@ namespace libp2p::connection {
 
   void QuicStream::writeSome(BytesIn in, basic::Writer::WriteCallbackFunc cb) {
     outcome::result<size_t> r = QuicError::STREAM_CLOSED;
-    if (not stream_ctx_) {
+    if (!stream_ctx_) {
       return cb(r);
     }
     if (stream_ctx_->writing) {
@@ -74,7 +74,7 @@ namespace libp2p::connection {
       stream_ctx_->writing.emplace(
           [weak_self{weak_from_this()}, in, cb{std::move(cb)}]() mutable {
             auto self = weak_self.lock();
-            if (not self) {
+            if (!self) {
               cb(QuicError::STREAM_CLOSED);
               return;
             }
@@ -108,7 +108,7 @@ namespace libp2p::connection {
   }
 
   void QuicStream::close(Stream::VoidResultHandlerFunc cb) {
-    if (not stream_ctx_) {
+    if (!stream_ctx_) {
       return cb(outcome::success());
     }
     lsquic_stream_shutdown(stream_ctx_->ls_stream, 1);
@@ -116,7 +116,7 @@ namespace libp2p::connection {
   }
 
   void QuicStream::reset() {
-    if (not stream_ctx_) {
+    if (!stream_ctx_) {
       return;
     }
     lsquic_stream_close(stream_ctx_->ls_stream);

--- a/src/transport/quic/transport.cpp
+++ b/src/transport/quic/transport.cpp
@@ -32,7 +32,7 @@ namespace libp2p::transport {
                            Multiaddress address,
                            TransportAdaptor::HandlerFunc cb) {
     auto r = detail::asQuic(address);
-    if (not r) {
+    if (!r) {
       return cb(r.error());
     }
     auto &info = r.value();
@@ -41,10 +41,10 @@ namespace libp2p::transport {
             outcome::result<boost::asio::ip::udp::resolver::results_type>
                 r) mutable {
           auto self = weak_self.lock();
-          if (not self) {
+          if (!self) {
             return;
           }
-          if (not r) {
+          if (!r) {
             return cb(r.error());
           }
           auto remote = r.value().begin()->endpoint();
@@ -55,7 +55,7 @@ namespace libp2p::transport {
               peer,
               [cb{std::move(cb)}](
                   outcome::result<std::shared_ptr<QuicConnection>> r) {
-                if (not r) {
+                if (!r) {
                   return cb(r.error());
                 }
                 cb(r.value());

--- a/src/transport/tcp/tcp_connection.cpp
+++ b/src/transport/tcp/tcp_connection.cpp
@@ -126,7 +126,7 @@ namespace libp2p::transport {
             bool expected = false;
             if (self->connection_phase_done_.compare_exchange_strong(expected,
                                                                      true)) {
-              if (not error) {
+              if (!error) {
                 // timeout happened, timer expired before connection was
                 // established
                 cb(boost::system::error_code{boost::system::errc::timed_out,
@@ -149,13 +149,13 @@ namespace libp2p::transport {
             return;
           }
           bool expected = false;
-          if (not self->connection_phase_done_.compare_exchange_strong(expected,
+          if (!self->connection_phase_done_.compare_exchange_strong(expected,
                                                                        true)) {
             BOOST_ASSERT(expected);
             // connection phase already done - means that user's callback was
             // already called by timer expiration so we are closing socket if
             // it was actually connected
-            if (not ec) {
+            if (!ec) {
               self->socket_.close();
             }
             return;

--- a/src/transport/tcp/tcp_connection.cpp
+++ b/src/transport/tcp/tcp_connection.cpp
@@ -150,7 +150,7 @@ namespace libp2p::transport {
           }
           bool expected = false;
           if (!self->connection_phase_done_.compare_exchange_strong(expected,
-                                                                       true)) {
+                                                                    true)) {
             BOOST_ASSERT(expected);
             // connection phase already done - means that user's callback was
             // already called by timer expiration so we are closing socket if

--- a/src/transport/tcp/tcp_transport.cpp
+++ b/src/transport/tcp/tcp_transport.cpp
@@ -15,7 +15,7 @@ namespace libp2p::transport {
                           multi::Multiaddress address,
                           TransportAdaptor::HandlerFunc handler) {
     auto r = detail::asTcp(address);
-    if (not r) {
+    if (!r) {
       return handler(r.error());
     }
     auto &[info, layers] = r.value();
@@ -27,7 +27,7 @@ namespace libp2p::transport {
          layers = std::move(layers)](
             outcome::result<boost::asio::ip::tcp::resolver::results_type>
                 r) mutable {
-          if (not r) {
+          if (!r) {
             return handler(r.error());
           }
           conn->connect(

--- a/test/libp2p/muxer/muxers_and_streams_test.cpp
+++ b/test/libp2p/muxer/muxers_and_streams_test.cpp
@@ -270,7 +270,7 @@ namespace libp2p::regression {
     }
 
     void onRead(outcome::result<void> res) {
-      if (not res.has_value()) {
+      if (!res.has_value()) {
         TRACE("({}): read error", stats_.node_id);
         stats_.put(Stats::READ_FAILURE);
       } else {
@@ -281,7 +281,7 @@ namespace libp2p::regression {
     }
 
     void onWrite(outcome::result<void> res) {
-      if (not res.has_value()) {
+      if (!res.has_value()) {
         TRACE("({}): write error", stats_.node_id);
         stats_.put(Stats::WRITE_FAILURE);
       } else {


### PR DESCRIPTION
This project also uses `!` elsewhere and `not` in older code, so this is not standardized. Since everyone else uses `!` for negation, there is not much reason to keep using `not`.