### PR TITLE
fix typo: occured -> occurred

### DIFF
--- a/include/libp2p/protocol_muxer/protocol_muxer.hpp
+++ b/include/libp2p/protocol_muxer/protocol_muxer.hpp
@@ -22,7 +22,7 @@ namespace libp2p::protocol_muxer {
       // cannot negotiate protocol
       NEGOTIATION_FAILED = 1,
 
-      // error occured on this host's side
+      // error occurred on this host's side
       INTERNAL_ERROR,
 
       // remote peer violated protocol

--- a/src/security/plaintext/plaintext.cpp
+++ b/src/security/plaintext/plaintext.cpp
@@ -44,7 +44,7 @@ OUTCOME_CPP_DEFINE_CATEGORY(libp2p::security, Plaintext::Error, e) {
   using E = libp2p::security::Plaintext::Error;
   switch (e) {
     case E::EXCHANGE_SEND_ERROR:
-      return "Error occured while sending Exchange message to the peer";
+      return "Error occurred while sending Exchange message to the peer";
     case E::EXCHANGE_RECEIVE_ERROR:
       return "Error occurred while receiving Exchange message to the peer";
     case E::INVALID_PEER_ID:


### PR DESCRIPTION
Fix two occurrences of 'occured' in a comment and an error message string.